### PR TITLE
RecSec feature geometric spreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,30 @@ synthetics in a directory called 'synthetic/'
 recsec --pysep_path observed/ --syn_path synthetic/ --cmtsolution DATA/CMTSOLUTION --stations DATA/STATIONS --synsyn
 ```
 
+### Scale by: Geometric Spreading
+
+Rather than normalizing traces, it is possible to scale peak amplitudes using
+a simple geometric spreading equation, which takes into account amplitude 
+loss due to propagation distance. See the docstring of 
+`recsec.RecordSection.calculate\_geometric\_spreading()` for more details on 
+how this is implemented. 
+
+To apply geometric spreading to data collected by PySEP for your record section:
+
+```bash
+recsec --pysep_path ./SAC --scale_by geometric_spreading 
+    --geometric_spreading_exclude STA1 STA2 STA3
+```
+
+Where `--geometric_spreading_exclude` is a list of stations that should *not* be
+included in the spreading equation (here, e.g., STA1 through STA3).
+
+Note that this option will generate a scatterplot showing the line fit to 
+the geometric spreading function. 
+
+Have a look at the RecSec init docstring for 'scale\_by' to see related 
+parameters (which start with *geometric_spreading_*) and how they should be used.
+
 --------------------------------------------------------------------------------
 
 ## Scripting PySEP

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -213,6 +213,7 @@ class RecordSection:
                 - `geometric_spreading_factor`
                 - `geometric_spreading_k_val`
                 - `geometric_spreading_exclude`
+                - `geometric_spreading_ymax`
                 Equation is A(d) = k / sin(d) ** f
                 Where A(d) is the amplitude reduction factor as a function of
                 distnace, d. 'k' is the `geometric_spreading_k_val` and 'f' is

--- a/pysep/utils/plot.py
+++ b/pysep/utils/plot.py
@@ -67,7 +67,7 @@ def plot_geometric_spreading(distances, max_amplitudes,
     if station_ids is not None:
         for x, y, s in zip(distances, max_amplitudes, station_ids):
             if ymax and y >= ymax:
-                plt.text(x, ymax, s, fontsize=8)
+                plt.text(x, ymax, f"{s}\n{y.max():.2E}", fontsize=8)
             else:
                 plt.text(x, y, s, fontsize=8)
 
@@ -92,7 +92,10 @@ def plot_geometric_spreading(distances, max_amplitudes,
     plt.xlabel("Source-Receiver Distance (deg)")
     plt.ylabel("Peak Amplitude")
     plt.xlim([0, x.max()])
-    plt.ylim([0, ymax * 1.25])
+    if ymax:
+        plt.ylim([0, ymax * 1.25])
+    else:
+        plt.ylim([0, y.max()])
     set_plot_aesthetic(ax=ax, xtick_fontsize=12, ytick_fontsize=12,
                        title_fontsize=13, label_fontsize=13,
                        xtick_minor=0.5, xtick_major=1)

--- a/pysep/utils/plot.py
+++ b/pysep/utils/plot.py
@@ -2,16 +2,106 @@
 """
 Pysep plotting utilities
 """
-import math
 import numpy as np
 import matplotlib.pyplot as plt
-
+from matplotlib.ticker import MultipleLocator
 from obspy.core.event import Catalog
 from obspy.geodetics import gps2dist_azimuth
-from obspy.taup import TauPyModel
 
 from pysep import logger
 from pysep.utils.fmt import format_event_tag
+
+
+def plot_geometric_spreading(distances, max_amplitudes,
+                             geometric_spreading_factor, geometric_k_value,
+                             station_ids=None, include=None, show=False,
+                             save="geometric_spreading.png", ymax=None,
+                             **kwargs):
+    """
+    Plot a scatter plot of peak amplitudes vs distance and a corresponding line
+    representing geometric scatter. Allow ignoring stations by index.
+
+    .. note::
+        see recsec.RecordSection._calculate_geometric_spreading() for more
+        information on this function
+
+    :type distances: list or np.array
+    :param distances: source-receiver distance in units of degrees
+    :type max_amplitudes: list or np.array
+    :param max_amplitudes: peak amplitudes, units irrelevant
+    :type geometric_spreading_factor: float
+    :param geometric_spreading_factor: exponent for spreading eq
+    :type geometric_k_value: float
+    :param geometric_k_value: constant scale factor for spreading eq
+    :type station_ids: list or np.array
+    :param station_ids: station ids for optional text labels
+    :type include: list or np.array
+    :param include: indices of stations included in equation, used for colors
+    :type show: bool
+    :param show: show the figure after generation
+    :type save: str
+    :param save: file name to save figure
+    :type ymax: float
+    :param ymax: set the ceiling y limit manually (incase some stations are
+        scaled improperly which would throw off all the scaling). Also cuts
+        off any stations above this limit and plots them differently
+    """
+    dpi = kwargs.get("dpi", 100)
+    figsize = kwargs.get("figsize", (12, 8))
+
+    logger.info(f"plotting geometric spreading: '{save}'")
+    f, ax = plt.subplots(1, dpi=dpi, figsize=figsize)
+
+    # Plot all stations in the list, specially mark excluded stations
+    for i, (x, y) in enumerate(zip(distances, max_amplitudes)):
+        if include and i not in include:
+            ec = "r"
+        else:
+            ec = "k"
+        if ymax and y >= ymax:
+            plt.scatter(x, ymax, marker="^", edgecolor=ec, c="w", s=50)
+        else:
+            plt.scatter(x, y, marker="o", edgecolor=ec, c="w", s=50)
+
+    # Plot station ids next to markers if given
+    if station_ids is not None:
+        for x, y, s in zip(distances, max_amplitudes, station_ids):
+            if ymax and y >= ymax:
+                plt.text(x, ymax, s, fontsize=8)
+            else:
+                plt.text(x, y, s, fontsize=8)
+
+    # Need to generate the line that w-vector follows
+    x = np.arange(1E-7, distances.max() * 1.5, 0.01)  # units: deg
+    sin_d = (np.sin(np.array(x) / (180 / np.pi)))
+    y = geometric_k_value / (sin_d ** geometric_spreading_factor)
+    l = f"A(d)={geometric_k_value:.2E} / (sin d)**{geometric_spreading_factor}"
+    w = plt.plot(x, y, "k--", lw=3, label=l)
+
+    # Create some legend markers
+    m1 = plt.scatter(-1, -1, edgecolor="k", c="w", marker="o",
+                     s=50, label="Included", linestyle="None")
+    m2 = plt.scatter(-1, -1, edgecolor="r", c="w", marker="o",
+                     s=50, label="Excluded", linestyle="None")
+    m3 = plt.scatter(-1, -1, edgecolor="r", c="w", marker="^",
+                     s=50, label="Out of Bounds", linestyle="None")
+    plt.legend(handles=[w[0], m1, m2, m3])
+
+    # Final touches for 'publication-ready' look
+    plt.title("Geometric Spreading Correction Factor: A(d)")
+    plt.xlabel("Source-Receiver Distance (deg)")
+    plt.ylabel("Peak Amplitude")
+    plt.xlim([0, x.max()])
+    plt.ylim([0, ymax * 1.25])
+    set_plot_aesthetic(ax=ax, xtick_fontsize=12, ytick_fontsize=12,
+                       title_fontsize=13, label_fontsize=13,
+                       xtick_minor=0.5, xtick_major=1)
+    plt.grid(visible=True, which="both", axis="y", alpha=0.5, linewidth=1)
+
+    if save:
+        plt.savefig(save)
+    if show:
+        plt.show()
 
 
 def plot_source_receiver_map(inv, event, save="./station_map.png",
@@ -85,69 +175,49 @@ def plot_source_receiver_map(inv, event, save="./station_map.png",
         plt.show()
 
 
-def plot_phases():
+def set_plot_aesthetic(ax, **kwargs):
     """
-    Tool to plot phases
+    Give a nice look to the output figure by creating thick borders on the
+    axis, adjusting fontsize etc. All plot aesthetics should be placed here
+    so it's easiest to find.
 
-    TODO fix this up
-
-    Kyle Smith
-    January 29,2018
-    :return:
+    .. note::
+        This was copy-pasted from Pyatoa.visuals.insp_plot.default_axes()
     """
-    phases=["S"]
-    phases2=["s"]
-    sourcedepth = 100
-    taup_model = "ak135"
-    dists = list(np.arange(0,180,1))
-    model = TauPyModel(model=taup_model)
-    Phase1arrivals = []
-    Phase2arrivals = []
-    Phase1_IA = []
-    Phase2_IA = []
-    for dist_deg in dists[:]:
-        temparr = model.get_travel_times(source_depth_in_km=sourcedepth,distance_in_degree=dist_deg,phase_list=[phases[0]])
-        temparr2 = model.get_travel_times(source_depth_in_km=sourcedepth,distance_in_degree=dist_deg,phase_list=[phases2[0]])
+    ytick_fontsize = kwargs.get("ytick_fontsize", 8)
+    xtick_fontsize = kwargs.get("xtick_fontsize", 12)
+    tick_linewidth = kwargs.get("tick_linewidth", 1.5)
+    tick_length = kwargs.get("tick_length", 5)
+    tick_direction = kwargs.get("tick_direction", "in")
+    label_fontsize = kwargs.get("label_fontsize", 10)
+    axis_linewidth = kwargs.get("axis_linewidth", 2.)
+    title_fontsize = kwargs.get("title_fontsize", 10)
+    xtick_minor = kwargs.get("xtick_minor", 25)
+    xtick_major = kwargs.get("xtick_major", 100)
+    spine_zorder = kwargs.get("spine_zorder", 8)
 
-        # there may be something wrong with obpsy and plotting since the error is that the arrivals does not have the attribute for plot_rays(), see Vipul's email for another way to plot.
-        try:
-            somearray = model.get_ray_paths(source_depth_in_km=sourcedepth,distance_in_degree=dist_deg,phase_list=[phases[0]])
+    ax.title.set_fontsize(title_fontsize)
+    ax.tick_params(axis="both", which="both", width=tick_linewidth,
+                        direction=tick_direction, length=tick_length)
+    ax.tick_params(axis="x", labelsize=xtick_fontsize)
+    ax.tick_params(axis="y", labelsize=ytick_fontsize)
+    ax.xaxis.label.set_size(label_fontsize)
+    ax.yaxis.label.set_size(label_fontsize)
 
-        except:
-            print('no somearray!')
+    # Thicken up the bounding axis lines
+    for axis in ["top", "bottom", "left", "right"]:
+        ax.spines[axis].set_linewidth(axis_linewidth)
 
-        if len(temparr)==0:
-            Phase1arrivals.append(math.nan)
-            Phase1_IA.append(math.nan)
-        else:
-            Phase1arrivals.append(temparr[0].time)
-            Phase1_IA.append(temparr[0].incident_angle)
-        if len(temparr2)==0:
-            Phase2arrivals.append(math.nan)
-            Phase2_IA.append(math.nan)
-        else:
-            Phase2arrivals.append(temparr2[0].time)
-            Phase2_IA.append(temparr2[0].incident_angle)
-    dkm = dists
-    #dkm = [a*111 for a in dists]
-    f1 = plt.figure(1)
-    L2, = plt.plot(dkm,Phase2arrivals,'ro',label=phases2[0])
-    L1, = plt.plot(dkm,Phase1arrivals,'b*',label=phases[0])
-    plt.xlim(0, 180)
-    plt.legend(handles=[L1,L2])
-    plt.ylabel("Time after EQ origin time (s)")
-    plt.xlabel("Source-Receiver Distance (deg)")
-    plt.title("Source depth:" + str(sourcedepth) + " km")
-    f1.show()
+    # Set spines above azimuth bins
+    for spine in ax.spines.values():
+        spine.set_zorder(spine_zorder)
 
-    f2 = plt.figure(2)
-    L2, = plt.plot(dkm,Phase2_IA,'ro',label=phases2[0])
-    L1, = plt.plot(dkm,Phase1_IA,'b*',label=phases[0])
-    plt.xlim(0, 180)
-    plt.legend(handles=[L1,L2])
-    plt.ylabel("Incident Angle(deg)")
-    plt.xlabel("Source-Receiver Distance(deg)")
-    plt.title("Source depth:" + str(sourcedepth) + " km")
-    f2.show()
+    # Set xtick label major and minor which is assumed to be a time series
+    ax.xaxis.set_major_locator(MultipleLocator(float(xtick_major)))
+    ax.xaxis.set_minor_locator(MultipleLocator(float(xtick_minor)))
 
-    input()
+    plt.sca(ax)
+    plt.grid(visible=True, which="major", axis="x", alpha=0.5, linewidth=1)
+    plt.grid(visible=True, which="minor", axis="x", alpha=0.2, linewidth=.5)
+
+    return ax


### PR DESCRIPTION
Addressing Issue #50 

- Adds in geometric spreading as a 'scale_by' option for RecSec
- Allows user to set parameters and exclude stations from geometric spreading equation
- Creates a scatter plot to show geometric spreading, following example shown in original post of #50 

>__NOTE__: Stations with poor data must be removed manually, otherwise they will throw off the scaling in the record section. This might be addressed in a future PR but at the moment since these data shouldn't be considered anyway, I think leaving it up to the User to remove them is sufficient

See e.g., below figures, which were generated using

```bash
$ pysep -p mtuq_workshop_2022 -e 2009-04-07T201255_ANCHORAGE.yaml
$ cd 2009-04-07T201255_ANCHORAGE
$ rm -r SAC/*RC01* SAC/*ALPI* SAC/*SPBG*  # getting rid of bad stations manually
$ recsec --pysep_path SAC/ --min_period_s 1 --max_period_s 100 --preprocess st \  
    --scale_by geometric_spreading --geometric_spreading_exclude KASH MPEN NSKI \   
    --geometric_spreading_ymax .0006  -o  
```
![geospread](https://user-images.githubusercontent.com/23055374/200440904-19f14fd6-c50d-44a9-bdc9-7afd297d3b78.png)
![recsec](https://user-images.githubusercontent.com/23055374/200440907-2a4fe9d4-773c-4a71-a93a-b67e9d959e07.png)

