### PR TITLE
Bugfix missing rotation metadata throwing TypeError

### DIFF
--- a/pysep/configs/test/test_config_rotate_bug.yaml
+++ b/pysep/configs/test/test_config_rotate_bug.yaml
@@ -1,0 +1,49 @@
+# Related to GitHub Issue #35, TypeError thrown when attempting to rotate
+# a stream with too little data. Channel 'UH?' (ultra long period) throws 
+# the error
+event_tag: null
+config_file: null
+client: IRIS
+client_debug: false
+timeout: 600
+taup_model: ak135
+event_selection: default
+origin_time: "2015-06-24T22:32:21.166000Z"
+seconds_before_event: 20
+seconds_after_event: 20
+event_latitude: 61.664
+event_longitude: -151.962
+event_depth_km: 114.2
+event_magnitude: 5.8
+networks: 'TA'
+stations: 'O1?K'
+channels: '*'
+# channels: 'BH?,LH?,UH?,VH?'  # These have missing dip or azi values
+locations: '*'
+reference_time: null
+seconds_before_ref: 100
+seconds_after_ref: 300
+phase_list: null
+mindistance: 0
+maxdistance: 20000.0
+minazimuth: 0
+maxazimuth: 360
+minlatitude: null
+maxlatitude: null
+minlongitude: null
+maxlongitude: null
+demean: true
+detrend: true
+taper_percentage: 0
+rotate:
+- ZNE
+- RTZ
+remove_response: true
+output_unit: VEL
+water_level: 60
+pre_filt: default
+scale_factor: 1
+resample_freq: null
+remove_clipped: false
+log_level: DEBUG
+kwargs: {}

--- a/pysep/configs/test/test_config_rotate_bug.yaml
+++ b/pysep/configs/test/test_config_rotate_bug.yaml
@@ -1,6 +1,6 @@
 # Related to GitHub Issue #35, TypeError thrown when attempting to rotate
-# a stream with too little data. Channel 'UH?' (ultra long period) throws 
-# the error
+# a stream with missing metadata. This issue is fixed but the Config is 
+# here to provide the station data used to test this issue
 event_tag: null
 config_file: null
 client: IRIS
@@ -16,9 +16,8 @@ event_longitude: -151.962
 event_depth_km: 114.2
 event_magnitude: 5.8
 networks: 'TA'
-stations: 'O1?K'
-channels: '*'
-# channels: 'BH?,LH?,UH?,VH?'  # These have missing dip or azi values
+stations: 'O18K'
+channels: 'BH?,LH?,UH?,VH?'  # These have missing dip or azi values
 locations: '*'
 reference_time: null
 seconds_before_ref: 100

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -28,7 +28,8 @@ from pysep.utils.cap_sac import (append_sac_headers, write_cap_weights_files,
                                  format_sac_headers_post_rotation)
 from pysep.utils.curtail import (curtail_by_station_distance_azimuth,
                                  quality_check_waveforms_before_processing,
-                                 quality_check_waveforms_after_processing)
+                                 quality_check_waveforms_after_processing,
+                                 )
 from pysep.utils.fmt import format_event_tag, format_event_tag_legacy, get_codes
 from pysep.utils.io import read_yaml, read_event_file, write_pysep_stations_file
 from pysep.utils.llnl import scale_llnl_waveform_amplitudes
@@ -872,7 +873,7 @@ class Pysep:
         if "sac_raw" in self.write_files:
             self.st_raw = st_raw.copy()
 
-        # Empty stream so we can take advantage of class __add__ method
+        # Empty stream, so we can take advantage of class __add__ method
         st_out = Stream()
 
         # RTZ requires rotating to ZNE first. Make sure this happens even if the
@@ -881,38 +882,55 @@ class Pysep:
             logger.info("rotating to components ZNE")
             st_zne = st_raw.copy()
             stations = set([tr.stats.station for tr in st_zne])
-            channels = set([tr.stats.channel[:-1] for tr in st_zne])
+            # Assuming each channel has its own azimuth and dip value
+            channels = set([f"{tr.stats.channel[:-1]}?" for tr in st_zne])
+            metadata_getter = self.inv.get_channel_metadata
             for sta in stations:
                 for cha in channels:
-                    _st = st_zne.select(station=sta, channel=f"{cha}?")
-                    _inv = self.inv.select(station=sta, channel=f"{cha}?")
-                    # Print out azimuth and dip angles for debugging purposes
-                    for _net in _inv:
-                        for _sta in _net:
-                            for _cha in _sta:
-                                logger.debug(
-                                    f"rotating -> ZNE "
-                                    f"{_net.code}.{_sta.code}.{_cha.code} with "
-                                    f"az={_cha.azimuth}, dip={_cha.dip}"
-                                )
-                    # components=['ZNE'] FORCES rotation using azimuth and dip 
-                    # values, even if components are already in 'ZNE'. This is 
-                    # important as some IRIS data will be in ZNE but not be 
+                    _st = st_zne.select(station=sta, channel=cha)
+
+                    # Check if 'dip' or 'azimuth' is None, because that causes
+                    # ObsPy rotate to throw a TypeError. See PySEP Issue #35
+                    channel_okay = bool(_st)
+                    for _tr in _st:
+                        try:
+                            meta = metadata_getter(_tr.id, _tr.stats.starttime)
+                            az = meta["azimuth"]
+                            dip = meta["dip"]
+                        except Exception:
+                            logger.warning(f"no matching metadata for {_tr.id}")
+                            channel_okay = False
+                            break
+
+                        logger.debug(f"{_tr.id} azimuth=={az}; dip=={dip}")
+                        if az is None or dip is None:
+                            channel_okay = False
+                            break
+
+                    if not channel_okay:
+                        logger.warning(f"{sta}.{cha} bad rotation metadata, "
+                                       f"removing")
+                        continue
+
+                    # components=['ZNE'] FORCES rotation using azimuth and dip
+                    # values, even if components are already in 'ZNE'. This is
+                    # important as some IRIS data will be in ZNE but not be
                     # aligned (https://github.com/obspy/obspy/issues/2056)
                     try:
-                        _st.rotate(method="->ZNE", inventory=self.inv, 
+                        _st.rotate(method="->ZNE", inventory=self.inv,
                                    components=["ZNE", "Z12", "123"])
                     # General error catching for rotation because any number of
                     # things can go wrong here based on the ObsPy rotation algo
                     except Exception as e:
-                        logger.warning(f"rotate issue for {sta}.{cha}?, "
+                        logger.warning(f"rotate issue for {sta}.{cha}, "
                                        "removing from stream")
                         logger.debug(f"rotate error: {e}")
                         continue
                     st_out += _st
             # Check to see if rotation errors kicked out all stations
             if not st_out:
-                logger.critical("rotation errors have reduced Stream to len 0")
+                logger.critical("rotation errors have reduced Stream to len 0, "
+                                "cannot continue")
                 sys.exit(-1)
             # Rotate to radial transverse coordinate system
             if "RTZ" in self.rotate:
@@ -920,15 +938,19 @@ class Pysep:
                 # If we rotate the ENTIRE stream at once, ObsPy only uses the 
                 # first backazimuth value which will create incorrect outputs
                 # https://github.com/obspy/obspy/issues/2623
-                st_rtz = st_out.copy()  
+                st_rtz = st_out.copy()  # contains ZNE rotated components
                 stations = set([tr.stats.station for tr in st_rtz])
                 for sta in stations:
-                    _st = st_rtz.select(station=sta)
-                    _st.rotate(method="NE->RT")  # in place rot.
-                    if hasattr(_st[0].stats, "back_azimuth"):
-                        logger.debug(f"{sta}: BAz={_st[0].stats.back_azimuth}")
-                    st_out += _st
-        elif "UVW" in self.rotate:
+                    _st = st_rtz.select(station=sta, channel=cha)
+                    if _st and hasattr(_st[0].stats, "back_azimuth"):
+                        _st.rotate(method="NE->RT")  # in place rot.
+                        st_out += _st
+                    else:
+                        logger.warning(f"no back azimuth for '{sta}', cannot "
+                                       f"rotate NE->RT")
+                        continue
+        # Allow UVW rotation independent on ENZ or RTZ rotation
+        if "UVW" in self.rotate:
             logger.info("rotating to components UVW")
             st_uvw = rotate_to_uvw(st_raw)
             st_out += st_uvw

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -133,7 +133,7 @@ def test_rotate_streams_fail(test_st, test_inv, test_event):
     Ensure that stream rotation does not go ahead if no back azimuth values are
     specified
     """
-    sep = Pysep(log_level="CRITICAL", rotate=["ZNE", "RTZ"])
+    sep = Pysep(log_level="DEBUG", rotate=["ZNE", "RTZ"])
     for tr in test_st:
         del tr.stats.back_azimuth
     assert("back_azimuth" not in test_st[0].stats)
@@ -143,10 +143,10 @@ def test_rotate_streams_fail(test_st, test_inv, test_event):
     sep.event = test_event
     sep.st = sep.preprocess()  # make sure that streams are formatted correctly
 
-    # No back aizmuth attribute found
-    with pytest.raises(TypeError):
-        sep.rotate_streams()
-
+    # No back aizmuth attribute found so streams will NOT be rotated
+    st = sep.rotate_streams()
+    components = set([tr.stats.component for tr in st])
+    assert(not {"R", "T"}.issubset(components))
 
 def test_rotate_streams(test_st, test_inv, test_event):
     """

--- a/pysep/utils/curtail.py
+++ b/pysep/utils/curtail.py
@@ -125,7 +125,7 @@ def remove_for_clipped_amplitudes(st):
     clip_factor = 0.8 * ((2 ** (24 - 1)) ** 2) ** 0.5  # For a 24-bit signal
     for tr in st_out[:]:
         # Figure out the if any amplitudes are clipped
-        if len(tr.data[np.abs(tr.data**2)**0.5 > clip_factor]):
+        if (tr.data[np.abs(tr.data**2)**0.5 > clip_factor]).any():
             logger.info(f"removing {tr.get_id()} for clipped amplitudes")
             st_out.remove(tr)
     return st_out


### PR DESCRIPTION
Related to #35, this PR fixes a bug in which missing rotation metadata (which comes from the datacenter) throws a TypeError during the ObsPy rotate command. 

Occasionally Station metadata (contained in the inventory) has NoneType set for the azimuth or dip of a given channel. Prior to this bugfix, this made its way into the obspy.signal.rotate2zne() function, which attempted to run a NoneType through a degrees to radian converter, causing a TypeError.

This bugfix PR addresses this by:
1) explicitly checking dip and azimuth values for each station in the Inventory. If any return NoneType, then PySEP will kick out the entire station to avoid an issue. 
2) the rotate function now addresses each grouping of channels individually (e.g., BHZ, BHE, BHN), whereas before all channels were considered together (and the underlying ObsPy rotation function took care of parsing). This lead to large-scale failures as one incorrect channel would cause the entire station to fail.
3) added a generic try-except to catch any errors in the ObsPy rotation so that it doesn't cause the entire program to crash. Stations that do not make it through are simply thrown own during rotation.

Added some test to cover these cases and a Config script that I used to do the bugfixing.