### PR TITLE
Remove llnl_db_client hard dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,5 @@ dependencies:
     - cartopy
     - pyyaml
     - pip:
-      - git+https://github.com/krischer/llnl_db_client.git
       - -e .
        

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
     "obspy",
     "cartopy",
     "pyyaml",
-    "llnl_db_client @ git+https://github.com/krischer/llnl_db_client.git"
 ]
 
 [project.optional-dependencies]
+llnl = ["llnl_db_client @ git+https://github.com/krischer/llnl_db_client.git"]
 test = ["pytest"]
 dev = ["pytest", "ipython", "ipdb"]
 

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -197,11 +197,11 @@ class Pysep:
         self.taup_model = taup_model
 
         # Check for LLNL requirement
-        if self.client == "LLNL":
-            assert(_has_llnl), (f"`client`=='LLNL' requires optional "
-                                f"dependency 'llnl_db_client' which was not "
-                                f"found. Please install PySEP with the command "
-                                f"'pip install -e .[llnl]")
+        if self.client == "LLNL" and not _has_llnl:
+            raise ImportError(f"`client`=='LLNL' requires optional "
+                              f"dependency 'llnl_db_client' which was not "
+                              f"found. Please reinstall PySEP with the command "
+                              f"'pip install -e .[llnl]")
 
         # Parameters related to event selection
         self.event_selection = event_selection

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1,19 +1,21 @@
 """
-Python Seismogram Extraction and Processing
+Python Seismogram Extraction and Processing (PySEP)
 
 Download, pre-process, and organize seismic waveforms, event and station
-metadata
-
-TODO
-    * flesh out the template config file
-    * save intermediate files? or some form of checkpointing
+metadata. Save waveforms as SAC files for use in moment tensor inversion and 
+adjoint tomography codes.
 """
 import argparse
 import os
 import sys
 import yaml
 import warnings
-import llnl_db_client  # NOQA
+try:
+    import llnl_db_client  # NOQA
+except ImportError:
+    _has_llnl = False
+else:
+    _has_llnl = True
 
 from glob import glob
 from pathlib import Path
@@ -146,6 +148,14 @@ class Pysep:
         :type phase_list: list of str
         :param phase_list: phase names to get ray information from TauP with.
             Defaults to direct arrivals 'P' and 'S'
+        :type seconds_before_event: float
+        :param seconds_before_event: only used if using the 'search' option for
+            `event_selection`. Time [s] before the given `origin_time` to search
+            for a matching catalog event from the given `client`
+        :type seconds_after_event: float
+        :param seconds_after_event: only used if using the 'search' option for
+            `event_selection`. Time [s] after the given `origin_time` to search
+            for a matching catalog event from the given `client`
         :type reference_time: str
         :param reference_time: Waveform origin time. Allows for a static time
             shift from the event origin time, e.g., if there are timing errors
@@ -186,6 +196,13 @@ class Pysep:
         self._password = password
         self.taup_model = taup_model
 
+        # Check for LLNL requirement
+        if self.client == "LLNL":
+            assert(_has_llnl), (f"`client`=='LLNL' requires optional "
+                                f"dependency 'llnl_db_client' which was not "
+                                f"found. Please install PySEP with the command "
+                                f"'pip install -e .[llnl]")
+
         # Parameters related to event selection
         self.event_selection = event_selection
         try:
@@ -214,7 +231,8 @@ class Pysep:
         self.seconds_after_ref = seconds_after_ref
         self.phase_list = phase_list
 
-        # NOTE: This default is a UAF LUNGS system-specific database path
+        # NOTE: This default is a UAF LUNGS system-specific database path.
+        # If you are not on LUNGS, you will need to set this path manually
         self.llnl_db_path = (
                 llnl_db_path or
                 "/store/raw/LLNL/UCRL-MI-222502/westernus.wfdisc"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
- Removes `llnl_db_client` as a hard dependency from python and conda install files to simplify install procedures 
- Hides `llnl_db_client` top level import behind a try-except block and has a check during init to see if LLNL is required
- Moves `llnl_db_client` to an optional install dependency which can be accessed via pip
- Adds in a legacy 'setup.py' file incase this is required by any future systems
- Tests still pass and tested install procedure and attempting to use LLNL client when not installed. All worked as expected