### PR TITLE
clean up docstrings of pysep/recsec, bugfix pysep restrictions

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -445,8 +445,7 @@ class Pysep:
                     "Event selection requires the following parameters: "
                     "`seconds_before_event` and `seconds_after_event`")
         elif self.event_selection == "default":
-            for par in [self.event_latitude, self.event_longitude,
-                        self.event_depth_km, self.event_magnitude]:
+            for par in [self.event_latitude, self.event_longitude]:
                 assert(par is not None), (
                     "`event_selection`=='default' requires "
                     "`event_latitude`, `event_longitude`, `event_depth_km` "
@@ -728,16 +727,27 @@ class Pysep:
         """
         logger.info("creating event metadata with user parameters")
 
+        if self.event_depth_km is not None:
+            depth = self.event_depth_km * 1E3
+        else:
+            depth = None
+
         origin = Origin(latitude=self.event_latitude,
                         longitude=self.event_longitude,
-                        depth=self.event_depth_km * 1E3,  # units: m
+                        depth=depth,  # units: m
                         time=self.origin_time
                         )
-        magnitude = Magnitude(mag=self.event_magnitude, magnitude_type="Mw")
+        if self.event_magnitude:
+            magnitude = Magnitude(mag=self.event_magnitude, magnitude_type="Mw")
+            magnitudes = [magnitude]
+        else:
+            magnitudes = []
 
-        event = Event(origins=[origin], magnitudes=[magnitude])
+        event = Event(origins=[origin], magnitudes=magnitudes)
         event.preferred_origin_id = origin.resource_id.id
-        event.preferred_magnitude_id = magnitude.resource_id.id
+
+        if magnitudes:
+            event.preferred_magnitude_id = magnitude.resource_id.id
 
         return event
 

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -72,44 +72,177 @@ class Pysep:
                  use_mass_download=False,
                  **kwargs):
         """
-        Define a default set of parameters
-
+        GENERAL DATA GATHERING
+        ======================
         :type client: str
         :param client: ObsPy FDSN client to query data from, e.g., IRIS, LLNL,
-            NCEDC or any FDSN clients accepted by ObsPy
-        :type network: str
-        :param network: name or names of networks to query for, if names plural,
-            must be a comma-separated list, i.e., "AK,AT,AV", else "AK".
-            Wildcard okay
-        :type station: str
-        :param station: station name or names to query for, wildcard okay
-        :type location: str
-        :param location: locations name or names to query for, wildcard okay
-        :type channel: str
-        :param channel: channel name or names to query for, wildcard okay
-        :type remove_response: bool
-        :param remove_response: Remove instrument response or not
-        :type remove_clipped: remove any clipped stations from final output
-        :param remove_clipped: Check if waveforms are clipped, remove if so
-        :type water_level: float
-        :param water_level: water_level to apply during filtering for small vals
+            NCEDC or any FDSN clients accepted by ObsPy. Defaults to 'IRIS'
+        :type minlatitude: float
+        :param minlatitude: for event, station and waveform retrieval. Defines
+            the minimum latitude for a rectangular bounding box that is used to
+            search for data. Only used for events if `event_selection`=='search'
+        :type maxlatitude: float
+        :param maxlatitude: for event, station and waveform retrieval. Defines
+            the maximum latitude for a rectangular bounding box that is used to
+            search for data. Only used for events if `event_selection`=='search'
+        :type minlongitude: float
+        :param minlongitude: for event, station and waveform retrieval. Defines
+            the minimum longitude for a rectangular bounding box that is used to
+            search for data. Only used for events if `event_selection`=='search'
+        :type maxlongitude: float
+        :param maxlongitude: for event, station and waveform retrieval. Defines
+            the maximum longitude for a rectangular bounding box that is used to
+            search for data. Only used for events if `event_selection`=='search'
+        :type user: str
+        :param user: User ID if IRIS embargoes data behind passwords. This is
+            passed into the instantiation of `client`.
+        :type password: str
+        :param password: Password if IRIS embargoes data behind passwords. This
+            is passed into the instantiation of 'client'
+        :type use_mass_download: bool
+        :param use_mass_download: Use ObsPy's mass download option to download
+            all available stations in the region regardless of data provider.
+        :type client_debug: bool
+        :param client_debug: turn on DEBUG mode for the ObsPy FDSN client, which
+            outputs information-rich log messages to std out. Use for debugging
+            when FDSN fails mysteriously.
+        :type timeout: float
+        :param timeout: time out time in units of seconds, passed to the
+            `client` to determine how long to wait for return data before
+            exiting. Defaults to 600s.
+        :type llnl_db_path: str
+        :param llnl_db_path: If `client`=='LLNL', PySEP assumes we are accesing
+            data from the LLNL waveeform database (which must be stored local).
+            Points to the path where this is saved.
+
+        EVENT SELECTION PARAMETERS
+        ==========================
+        :type event_selection: str
+        :param event_selection: How to define the Event which is used to define
+            the event origin time and hypocentral location.
+            - 'default': User defines Event `origin_time`, and location witih
+                `event_latitude` and `event_longitude`
+            - 'search': PySEP will use `client` to search for a Catalog event
+                defined by `event_origintime`, `event_magnitude` and
+                `event_depth_km`. Buffer time around the `origin_time` can
+                be defined by `seconds_before_event` and `seconds_after_event`.
+        :type origin_time: str
+        :param origin_time: the event origin time used as a central reference
+            point for data gathering. Must be in a string format that is
+            recognized by ObsPy UTCDateTime. For example '2000-01-01T00:00:00'.
+        :type event_latitude: float
+        :param event_latitude: latitude of the event in units of degrees.
+            used for defining the event hypocenter and for removing stations
+            based on distance from the event.
+        :type event_longitude: float
+        :param event_longitude: longitude of the event in units of degrees.
+            used for defining the event hypocenter and for removing stations
+            based on distance from the event.
+        :type seconds_before_event: float
+        :param seconds_before_event: For event selection only, only used if
+            `event_selection`=='search'. Time [s] before given `origin_time` to
+            search for a matching catalog event from the given `client`
+        :type seconds_after_event: float
+        :param seconds_after_event: For event selection only, only used if
+            `event_selection`=='search'. Time [s] after given `origin_time` to
+            search for a matching catalog event from the given `client`
+
+        WAVEFORM + STATION METADATA GATHERING PARAMETERS
+        ================================================
+        :type reference_time: str
+        :param reference_time: Waveform origin time. If not given, defaults to
+            the event origin time. This allows for a static time shift from the
+            event origin time, e.g., if there are timing errors with relation
+            to the `origin_time`. Defaults to NoneType (`origin_time`).
+        :type seconds_before_ref: float
+        :param seconds_before_ref: For waveform fetching. Defines the time
+            before `reference_time` to fetch waveform data. Units [s]
+        :type seconds_after_ref: float
+        :param seconds_after_ref: For waveform fetching. Defines the time
+            after `reference_time` to fetch waveform data. Units [s]
+        :type networks: str
+        :param networks: name or names of networks to query for, if names plural,
+            must be a comma-separated list, i.e., 'AK,AT,AV'. Wildcards okay,
+            defaults to '*'.
+        :type stations: str
+        :param stations: station name or names to query for. If multiple
+            stations, input as a list of comma-separated values, e.g.,
+            'STA01,STA02,STA03'. Wildcards acceptable, if using wildcards, use
+            a '-' to exclude stations (e.g., '*,-STA01' will gather all stations
+            available, except STA01. Defaults to '*'
+        :type locations: str
+        :param locations: locations name or names to query for, wildcard okay.
+            See `stations` for inputting multiple location values. Default '*'.
+        :type channels: str
+        :param channels: channel name or names to query for, wildcard okay. If
+            multiple stations, input as a list of comma-separated values, e.g.,
+            'HH?,BH?'. Wildcards acceptable. Defaults to '*'.
+
+        STATION REMOVAL PARAMETERS
+        ==========================
+        :type mindistance: float
+        :param mindistance: Used for removing stations and mass download option
+            - Removing stations: Remove any stations who are closer than the
+            given minimum distance away from event (units: km). Always applied
+            - Mass Download: If `use_mass_download` is True and
+            `domain_type`=='circular', defines the minimum radius around the
+            event hypocenter to gather waveform data and station metadata
+        :type maxdistance: float
+        :param maxdistance: Used for removing stations and mass download option
+            - Removing stations: Remove any stations who are farther than the
+            given maximum distance away from event (units: km). Always applied
+            - Mass Download: If `use_mass_download` is True and
+            `domain_type`=='circular', defines the maximum radius around the
+            event hypocenter to gather waveform data and station metadata
+        :type minazimuth: float
+        :param minazimuth: for station removal. stations whose azimuth relative
+            to the event hypocenter that do not fall within the bounds
+            [`minazimuth`, `maxazimuth`] are removed from the final list.
+            Defaults to 0 degrees.
+        :param minazimuth: for station removal. stations whose azimuth relative
+            to the event hypocenter that do not fall within the bounds
+            [`minazimuth`, `maxazimuth`] are removed from the final list.
+            Defaults to 360 degrees.
+        :type remove_clipped: float
+        :param remove_clipped: remove any clipped stations from gathered
+            stations. Checks the max amplitude of against a maximum value
+            expected for a 24 bit signal.
+
+        DATA PROCESSING PARAMETERS
+        ==========================
         :type detrend: bool
-        :param detrend: apply simple detrend to data during preprocessing
+        :param detrend: apply simple linear detrend to data during prior to
+            removing instrument response (if `remove_response`==True)
         :type demean: bool
-        :param demean: apply demeaning to data during preprocessing
+        :param demean: apply demeaning to data during instrument reseponse
+            removal. Only applied if `remove_response` == True.
         :type taper: float
         :param taper: apply a taper to the waveform with ObsPy taper, fraction
             between 0 and 1 as the percentage of the waveform to be tapered
             Applied generally used when data is noisy, e.g., HutchisonGhosh2016
-            To get the same results as the default taper in SAC,
+            Note: To get the same results as the default taper in SAC,
             use max_percentage=0.05 and leave type as hann.
-            Tapering also happens while resampling (see util_write_cap.py)
-        :type rotate: list of str
+            Tapering also happens while resampling (see util_write_cap.py).
+             Only applied if `remove_response` == True.
+        :type rotate: list of str or NoneType
         :param rotate: choose how to rotate the waveform data. Can include
             the following options (order insensitive):
             * ZNE: Rotate from arbitrary components to North, East, Up
             * RTZ: Rotate from ZNE to Radial, Transverse, Up (requires ZNE)
             * UVW: Rotate from ZNE to orthogonal UVW orientation
+            If set to None, no rotation processing will take place.
+        :type remove_response: bool
+        :param remove_response: remove instrument response using station
+            response information gathered from `client`. Defaults to True.
+        :type output_unit: str
+        :param output_unit: the output format of the waveforms if instrument
+            response removal is applied. Only relevant if \
+            `remove_response`==True. See ObsPy.core.trace.Trace.remove_response
+             for acceptable values. Typical values are: 'DISP', 'VEL', 'ACC'
+             (displacement [m], velocity [m/s], acceleration [m/s^2]).
+        :type water_level: float
+        :param water_level: a water level threshold to apply during filtering
+            for small values. Passed to Obspy.core.trace.Trace.remove_response
         :type prefilt: str, tuple or NoneType
         :param prefilt: apply a pre-filter to the waveforms before deconvolving
             instrument response. Options are:
@@ -120,77 +253,76 @@ class Pysep:
             * NoneType: do not apply any pre-filtering
             * tuple of float: (f0, f1, f2, f3) define the corners of your pre
                 filter in units of frequency (Hz)
-        :type mindistance: float
-        :param mindistance: get waveforms from stations starting from a minimum
-            distance away  from event (km)
-        :type maxdistance: float
-        :param maxdistance: get waveforms from stations up to a maximum distance
-            from event (km)
-        :type minazimuth: float
-        :param minazimuth: get waveforms from a station starting at a given
-            minimum azimuth (deg) out to a final maximum azimuth (deg) where
-            0 degrees points North from the event
-        :type maxazimuth: float
-        :param maxazimuth: get waveforms from a station starting at a given
-            minimum azimuth (deg) out to a final maximum azimuth (deg) where
-            0 degrees points North from the event
-        :type minlatitude: float
-        :param minlatitude: minimum latitude for bounding box to search for
-            stations and events
-        :type maxlatitude: float
-        :param maxlatitude: maximum latitude for bounding box to search for
-            stations and events
-        :type minlongitude: float
-        :param minlongitude: minimum longitude for bounding box to search for
-            stations and events
-        :type maxlongitude: float
-        :param maxlongitude: maximum longitude for bounding box to search for
-            stations and events
         :type resample_freq: float
-        :param resample_freq: frequency to resample data at
+        :param resample_freq: frequency to resample data in units Hz. If not
+            given, no data resampling will take place. Defaults to NoneType
         :type scale_factor: float
-        :param scale_factor: scale data by a constant, for CAP use 10**2
-            (to convert m/s to cm/s)
+        :param scale_factor: scale all data by a constant factor
+            Note: for CAP use 10**2 (to convert m/s to cm/s).
+            Defaults to NoneType (no scaling applied)
+
+        SAC HEADERS
+        ===========
         :type phase_list: list of str
         :param phase_list: phase names to get ray information from TauP with.
-            Defaults to direct arrivals 'P' and 'S'
-        :type seconds_before_event: float
-        :param seconds_before_event: only used if using the 'search' option for
-            `event_selection`. Time [s] before the given `origin_time` to search
-            for a matching catalog event from the given `client`
-        :type seconds_after_event: float
-        :param seconds_after_event: only used if using the 'search' option for
-            `event_selection`. Time [s] after the given `origin_time` to search
-            for a matching catalog event from the given `client`
-        :type reference_time: str
-        :param reference_time: Waveform origin time. Allows for a static time
-            shift from the event origin time, e.g., if there are timing errors
-            with relation to o time. If not given, defaults to event origin time
-        :type seconds_before_ref: float
-        :param seconds_before_ref: time before origintime to fetch waveform data
-        :type seconds_after_ref: float
-        :param seconds_after_ref: time after origintime to fetch waveform data
+            Defaults to direct arrivals 'P' and 'S'. Must match Phases expected
+            by TauP (see ObsPy TauP documentation for acceptable phases). Phase
+            information will be added to SAC headers.
         :type taup_model: str
         :param taup_model: name of TauP model to use to calculate phase arrivals
-        :type output_unit: str
-        :param output_unit: the output format of the waveforms, something like
-            'DISP', 'VEL', 'ACC'
-        :type user: str
-        :param user: User ID if IRIS embargoes data behind passwords
-        :type password: str
-        :param password: Password if IRIS embargoes data behind passwords
+            See also `phase_list` which defines phases to grab arrival data
+            for. Defaults to 'AK135'. See ObsPy TauP documentation for avilable
+            models.
+
+        PYSEP-SPECIFIC PARAMETERS
+        =========================
+        :type config_file: str
+        :param config_file: path to YAML configuration file which will be used
+            to overwrite internal default parameters. Used for command-line
+            version of PySEP
+        :log_level: str
+        :param log_level: Level of verbosity for the internal PySEP logger.
+            In decreasing order of verbosity: 'DEBUG', 'INFO', 'WARNING',
+            'CRITICAL'
+        :type write_files: str or NoneType
+        :param write_files: Which files to write out after data gathering.
+            Should be a comma-separated list of the following
+            - weights_az: write out CAP weight file sorted by azimuth
+            - weights_dist: write out CAP weight file sorted by distance
+            - weights_code: write out CAP weight file sorted by station code
+            - station_list: write out a text file with station informatino
+            - inv: save a StationXML (.xml) file (ObsPy inventory)
+            - event: save a QuakeML (.xml) file (ObsPy Catalog)
+            - stream: save an ObsPy stream in Mseed (.ms) (ObsPy Stream)
+            - config_file: save YAML config file containing all input parameters
+            - sac: save all waveforms as SAC (.sac) files separated by component
+            - sac_raw: save the raw (pre-rotation) SAC files
+            - all: write all of the above (default value)
+            Example input: `write_files`=='inv,event,stream,sac'
+            If None, no files will be written. This is generally not advised.
+        :type plot_files: str or NoneType
+        :param write_files: What to plot after data gathering.
+            Should be a comma-separated list of the following
+            - map: plot a source-receiver map with event and all stations
+            - record_section: plot a record section with default parameters
+            - all: plot all of the above (default value)
+            If None, no files will be plotted.
+        :type output_dir: str
+        :param output_dir: path to output directory where all the files and
+            figures defined by `write_files` and `plot_files` will be stored.
+            Defaults to the current working directory.
         :type overwrite: bool
-        :param overwrite: overwrite an existing PySEP event directory if
-            the current process is trying to write to it
+        :param overwrite: If True, overwrite an existing PySEP event directory.
+            This prevents Users from re-downloading data. Defaults to False.
         :type legacy_naming: bool
-        :param legacy_naming: revert to old PySEP naming schema for event tag,
-            which names the directory and output SAC files
+        :param legacy_naming: if True, revert to old PySEP naming schema for
+            event tags, which is responsible for naming the output directory and
+            SAC files. Legacy filenames look something like
+            '20000101000000.NN.SSS.LL.CC.c' (event origin time, network,
+            station, location, channel, component). Default to False
         :type overwrite_event_tag: str
         :param overwrite_event_tag: option to allow the user to set their own
             event tag, rather than the automatically generated one
-        :type use_mass_download: bool
-        :param use_mass_download: Use ObsPy's mass download option to download
-            all available stations in the region regardless of data provider.
         """
         # Internal attribute but define first so that it sits at the top of
         # written config files
@@ -1139,8 +1271,7 @@ class Pysep:
         # but really this set is just required by check(), not by write()
         _acceptable_files = {"weights_az", "weights_dist", "weights_code",
                              "station_list", "inv", "event", "stream",
-                             "config_file", "sac", "sac_raw", "sac_rotated", 
-                             "all"}
+                             "config_file", "sac", "sac_raw", "all"}
         if _return_filenames:
             return _acceptable_files
 

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1520,7 +1520,8 @@ class Pysep:
         self.st = append_sac_headers(self.st, self.event, self.inv)
         if self.taup_model is not None:
             self.st = format_sac_header_w_taup_traveltimes(self.st, 
-                                                           self.taup_model)
+                                                           self.taup_model,
+                                                           self.phase_list)
 
         # Waveform preprocessing and standardization
         self.st = self.preprocess()

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -116,10 +116,10 @@ class Dict(dict):
 
 class RecordSection:
     """
-    Record section plotting tool which takes ObsPy streams and 
-    1) preprocesses and filters waveforms,
-    2) sorts source-receiver pairs based on User input, 
-    3) produces record section waveform figures.
+    Record section plotting tool which takes ObsPy streams and:
+        1) preprocesses and filters waveforms,
+        2) sorts source-receiver pairs based on User input,
+        3) produces record section waveform figures.
     """
     def __init__(self, pysep_path=None, syn_path=None, stations=None,
                  cmtsolution=None, st=None, st_syn=None, sort_by="default",
@@ -136,21 +136,22 @@ class RecordSection:
                  overwrite=False, log_level="DEBUG", cartesian=False,
                  synsyn=False, **kwargs):
         """
-        Set the default record section plotting parameters and enforce types.
-        Run some internal parameter derivation functions by manipulating input
-        data and parameters.
+        READING INPUT DATA PARAMETERS
+        =============================
 
+        PYSEP-GENERATED WAVEFORMS
+        -------------------------
         :type pysep_path: str
         :param pysep_path: path to Pysep output, which is expected to contain
-            trace-wise SAC waveform files which will be read
+            trace-wise SAC waveform files which will be read in.
+
+        SPECFEM-GENERATED SYNTHETICS
+        ----------------------------
         :type syn_path: str
-        :param syn_path: path to SPECFEM generated ASCII synthetics.
-        :type st: obspy.core.stream.Stream
-        :param st: Stream objects containing observed time series to be plotted
-            on the record section. Can contain any number of traces
-        :type st_syn: obspy.core.stream.Stream
-        :param st_syn: Stream objects containing synthetic time series to be
-            plotted on the record section. Must be same length as `st`
+        :param syn_path: full path to directory containing synthetic
+            seismograms that have been outputted by SPECFEM. The synthetics
+            are expected in the format: '*??.*.*.sem?*', which generally matches
+            SPECFEM files like 'NZ.BFZ.BXE.semd'
         :type stations: str
         :param stations: full path to STATIONS file used to define the station
             coordinates. Format is dictated by SPECFEM
@@ -158,10 +159,33 @@ class RecordSection:
         :type cmtsolution: required for synthetics, full path to SPECFEM source
             file, which was used to generate SPECFEM synthetics. Example
             filenames are CMTSOLUTION, FORCESOLUTION, SOURCE.
+        :type cartesian: bool
+        :param cartesian: lets RecSec know that the domain is set in Cartesian
+            coordinates (SPECFEM2D or SPECFEM3D_CARTESIAN in UTM), such that
+            data/metadata reading will need to adjust acoordingly because the
+            ObsPy tools used to read metadata will fail for domains defined in
+            XYZ
+        :type synsyn: bool
+        :param synsyn: flag to let RecSec know that we are plotting two sets
+            of synthetic seismograms. Such that both `pysep_path` and `syn_path`
+            will be both attempt to read in synthetic data. Both sets of
+            synthetics MUST share the same `cmtsolution` and `stations` metadata
+
+        USER-DEFINED DATA
+        -----------------
+        :type st: obspy.core.stream.Stream
+        :param st: Stream objects containing observed time series to be plotted
+            on the record section. Can contain any number of traces
+        :type st_syn: obspy.core.stream.Stream
+        :param st_syn: Stream objects containing synthetic time series to be
+            plotted on the record section. Must be same length as `st`
+
+        WAVEFORM PLOTTING ORGANIZATION PARAMETERS
+        =========================================
         :type sort_by: str
         :param sort_by: How to sort the Y-axis of the record section, available:
             - 'default': Don't sort, just iterate directly through Stream
-            - 'alphabetical': sort alphabetically A->Z. Components sorted 
+            - 'alphabetical': sort alphabetically A->Z. Components sorted
                 separately with parameter `components`
             - 'azimuth': sort by source-receiver azimuth (deg) with constant
                 vertical spacing on the y-axis. Requires `azimuth_start_deg`
@@ -183,7 +207,7 @@ class RecordSection:
             - 'normalize': scale each trace by the maximum amplitude,
                 i.e., > a /= max(abs(a))  # where 'a' is time series amplitudes
             - 'global_norm': scale by the largest amplitude to be displayed on
-                the screen. Will not consider waveforms which have been 
+                the screen. Will not consider waveforms which have been
                 excluded on other basis (e.g., wrong component)
                 i.e., > st[i].max /= max([max(abs(tr.data)) for tr in st])
             - 'geometric_spreading': scale amplitudes by expected reduction
@@ -224,22 +248,28 @@ class RecordSection:
             their source receiver distance. This parameter will be ADDED
             to time_shift_s (both float and list), if it is provided.
             Should be in units of `distance_units`/s
-        :type min_period_s: float
-        :param min_period_s: minimum filter period in seconds
-        :type max_period_s: float
-        :param max_period_s: maximum filter period in seconds
+        :type azimuth_start_deg: float
+        :param azimuth_start_deg: If sorting by azimuth, this defines the
+            azimuthal angle for the waveform at the top of the figure.
+            Set to 0 for default behavior
+        :type distance_units: str
+        :param distance_units: Y-axis units when sorting by epicentral distance
+            'km': kilometers on the sphere
+            'deg': degrees on the sphere
+            'km_utm': kilometers on flat plane, UTM coordinate system
+
+        DATA PROCESSING PARAMETERS
+        ==========================
         :type preprocess: str
         :param preprocess: choose which data to preprocess, options are:
             - None: do not run preprocessing step, including filter (Default)
             - 'st': process waveforms in `st`
             - 'st_syn': process waveforms in `st_syn`. st still must be given
             - 'both': process waveforms in both `st` and `st_syn`
-        :type max_traces_per_rs: int
-        :param max_traces_per_rs: maximum number of traces to show on a single
-            record section plot. Defaults to all traces in the Stream
-        :type xlim_s: list of float
-        :param xlim_s: [start, stop] in units of time, seconds, to set the
-            xlimits of the figure
+        :type min_period_s: float
+        :param min_period_s: minimum filter period in seconds
+        :type max_period_s: float
+        :param max_period_s: maximum filter period in seconds
         :type components: str
         :param components: a sequence of strings representing acceptable
             components from the data. Also determines the order these are shown
@@ -253,31 +283,9 @@ class RecordSection:
             e.g., if integrate == 2,  will integrate each trace twice.
             or    if integrate == -1, will differentiate once
             or    if integrate == 0,  do nothing (default)
-        :type y_axis_spacing: float
-        :param y_axis_spacing: spacing between adjacent seismograms applied to
-            Y-axis on relative (not absolute) scales. Defaults to 1.
-        :type y_label_loc: str
-        :param y_label_loc: Location to place waveform labels on the y-axis
-            - 'default': auto choose the best location based on `sort_by`
-            - 'y_axis': Replace tick labels on the y-axis (left side of figure),
-                This won't work if using absolute sorting and will be over-
-                written by 'default'
-            - 'y_axis_right': Replace tick labels on the right side of the 
-                y-axis. This option won't work with absolute sorting
-            - 'x_min': Place labels on top of the waveforms at the global min
-                x-value on the figure
-            - 'x_min': Place labels on top of the waveforms at the global max
-                x-value on the figure
-            - None: Don't plot any text labels
-        :type azimuth_start_deg: float
-        :param azimuth_start_deg: If sorting by azimuth, this defines the 
-            azimuthal angle for the waveform at the top of the figure.
-            Set to 0 for default behavior
-        :type distance_units: str
-        :param distance_units: Y-axis units when sorting by epicentral distance
-            'km': kilometers on the sphere
-            'deg': degrees on the sphere
-            'km_utm': kilometers on flat plane, UTM coordinate system
+
+        GEOMETRIC SPREADING PARAMETERS
+        ==============================
         :type geometric_spreading_factor: float
         :param geometric_spreading_factor: factor to scale amplitudes by
             predicting the expected geometric spreading amplitude reduction and
@@ -299,8 +307,33 @@ class RecordSection:
             whatever the peak y-value plotted is.
         :type geometric_spreading_save: str
         :param geometric_spreading_save: file id to save separate geometric
-            spreading scatter plot iff `scale_by`=='geometric_spreading'. If 
+            spreading scatter plot iff `scale_by`=='geometric_spreading'. If
             NoneType, will not save. By default, turned OFF
+
+        FIGURE GENERATION PARAMETERS
+        ============================
+        :type max_traces_per_rs: int
+        :param max_traces_per_rs: maximum number of traces to show on a single
+            record section plot. Defaults to all traces in the Stream
+        :type xlim_s: list of float
+        :param xlim_s: [start, stop] in units of time, seconds, to set the
+            xlimits of the figure
+        :type y_axis_spacing: float
+        :param y_axis_spacing: spacing between adjacent seismograms applied to
+            Y-axis on relative (not absolute) scales. Defaults to 1.
+        :type y_label_loc: str
+        :param y_label_loc: Location to place waveform labels on the y-axis
+            - 'default': auto choose the best location based on `sort_by`
+            - 'y_axis': Replace tick labels on the y-axis (left side of figure),
+                This won't work if using absolute sorting and will be over-
+                written by 'default'
+            - 'y_axis_right': Replace tick labels on the right side of the
+                y-axis. This option won't work with absolute sorting
+            - 'x_min': Place labels on top of the waveforms at the global min
+                x-value on the figure
+            - 'x_min': Place labels on top of the waveforms at the global max
+                x-value on the figure
+            - None: Don't plot any text labels
         :type figsize: tuple of float
         :param figsize: size the of the figure, passed into plt.subplots()
         :type show: bool
@@ -308,22 +341,16 @@ class RecordSection:
         :type save: str
         :param save: path to save output figure, will create the parent
             directory if it doesn't exist. If None, will not save.
+
+        RECORD SECTION PARAMETERS
+        =========================
         :type overwrite: bool
         :param overwrite: if the path defined by `save` exists, will overwrite
             the existing figure
         :type log_level: str
-        :param log_level: level of the internal logger, 'WARNING', 'INFO',
-            'DEBUG'.
-        :type cartesian: bool
-        :param cartesian: lets RecSec know that the domain is set in Cartesian
-            coordinates, such that data/metadata reading will need to adjust
-            acoordingly because the ObsPy tools used to read metadata will fail
-            for domains defined in XYZ
-        :type synsyn: bool
-        :param synsyn: flag to let RecSec know that we are plotting two sets
-            of synthetic seismograms. Such that both `pysep_path` and `syn_path`
-            will be read in as synthetics. Both sets of synthetics MUST share
-            the same SOURCE and STATIONS metadata
+        :param log_level: level of the internal logger. In order of ascending
+            verbosity: 'CRITICAL', 'WARNING', 'INFO', 'DEBUG'.
+
         :raises AssertionError: if any parameters are set incorrectly
         """
         # Set the logger level before running anything
@@ -433,7 +460,7 @@ class RecordSection:
         self.sorted_idx = []
 
     def _generate_synthetic_stream(self, syn_path, source, stations,
-                                   cartesian=False, fmt="*??.*.*.sem?*"):
+                                   cartesian=False, fmt="*.*.*.sem?*"):
         """
         Convenience fucntion to read in synthetic seismograms from SPECFEM2D,
         SPECFEM3D or SPECFEM3D_GLOBE. Can be used to read in both `st` and

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -105,28 +105,6 @@ from pysep.utils.plot import plot_geometric_spreading, set_plot_aesthetic
 DEG = u"\N{DEGREE SIGN}"
 
 
-def myround(x, base=5, choice="near"):
-    """
-    Round value x to nearest base, round 'up','down' or to 'near'est base
-
-    :type x: float
-    :param x: value to be rounded
-    :type base: int
-    :param base: nearest integer to be rounded to
-    :type choice: str
-    :param choice: method of rounding, 'up', 'down' or 'near'
-    :rtype roundout: int
-    :return: rounded value
-    """
-    if choice == "near":
-        roundout = int(base * round(float(x)/base))
-    elif choice == "down":
-        roundout = int(base * np.floor(float(x)/base))
-    elif choice == "up":
-        roundout = int(base * np.ceil(float(x)/base))
-    return roundout
-
-
 class Dict(dict):
     """Simple dictionary overload for nicer get/set attribute characteristics"""
     def __setattr__(self, key, value):
@@ -1862,6 +1840,16 @@ class RecordSection:
         )
         self.ax.set_title(title)
 
+    def run(self):
+        """
+        Convenience run function to run the RecordSection workflow in order.
+        No internal logic for breaking the figure up into multiple record
+        sections. For that see main function `plotw_rs`.
+        """
+        self.process_st()
+        self.get_parameters()
+        self.plot()
+
 
 def parse_args():
     """
@@ -2030,9 +2018,9 @@ def parse_args():
 
 def plotw_rs(*args, **kwargs):
     """
-    Main call function, replacing `plotw_rs`. Run the record section plotting
-    functions in order. Contains the logic for breaking up figure into multiple
-    pages.
+    Main call function for command line use of RecordSection.
+    Runs the record section plotting functions in order. Contains the logic for
+    breaking up figure into multiple pages.
 
     .. note::
         All arguments should be parsed into the argparser, *args and **kwargs

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -222,7 +222,7 @@ def _append_sac_headers_trace(tr, event, inv):
     return tr
 
 
-def format_sac_header_w_taup_traveltimes(st, model="ak135"):
+def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
     """
     Add TauP travel times to the SAC headers using information in the SAC header
     Also get some information from TauP regarding incident angle, takeoff angle
@@ -243,13 +243,19 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135"):
     :type model: str
     :param model: name of the TauP model to use for arrival times etc.
         defaults to 'ak135'
+    :type phase_list: list of str
+    :param phase_list: phase names to get ray information from TauP with.
+        Defaults to direct arrivals 'P' and 'S'. Must match Phases expected
+        by TauP (see ObsPy TauP documentation for acceptable phases).
     """
     st_out = st.copy()
 
     # Call TauP with a specific model to retrieve travel times etc.
-    phases = ["p", "P", "s", "S"]
+    if not phase_list:
+        phase_list = ["p", "P", "s", "S"]
+
     phase_dict = get_taup_arrivals_with_sac_headers(st=st, model=model,
-                                                    phase_list=phases)
+                                                    phase_list=phase_list)
     # Arrivals may return multiple entires for each phase, pick earliest
     for tr in st_out[:]:
         arrivals = phase_dict[tr.get_id()]

--- a/pysep/utils/curtail.py
+++ b/pysep/utils/curtail.py
@@ -77,25 +77,29 @@ def curtail_by_station_distance_azimuth(event, inv, mindistance=0.,
     return inv
 
 
-def quality_check_waveforms_before_processing(st):
+def quality_check_waveforms_before_processing(st, remove_clipped=True):
     """
     Quality assurance to deal with bad data before running the
     preprocessing steps. Replaces: `do_waveform_QA`
 
     :type st: obspy.core.stream.Stream
     :param st: Stream object to pass through QA procedures
+    :type remove_clipped: bool
+    :param remove_clipped: boolean flag to turn on/off amplitude clipping check
     """
     st_out = st.copy()
 
     st_out = rename_channels(st_out)
     st_out = remove_stations_for_missing_channels(st_out)  # LL network ONLY!
     st_out = remove_traces_for_bad_data_types(st_out)
-    st_out = remove_for_clipped_amplitudes(st_out)
+    if remove_clipped:
+        st_out = remove_for_clipped_amplitudes(st_out)
 
     return st_out
 
 
-def quality_check_waveforms_after_processing(st):
+def quality_check_waveforms_after_processing(st,
+                                             remove_insufficient_length=True):
     """
     Quality assurance to deal with bad data after preprocessing, because
     preprocesing step will merge, filter and rotate data.
@@ -103,10 +107,14 @@ def quality_check_waveforms_after_processing(st):
 
     :type st: obspy.core.stream.Stream
     :param st: Stream object to pass through QA procedures
+    :type remove_insufficient_length: bool
+    :param remove_insufficient_length: boolean flag to turn on/off insufficient
+        length checker
     """
     st_out = st.copy()
 
-    st_out = remove_stations_for_insufficient_length(st_out)
+    if remove_insufficient_length:
+        st_out = remove_stations_for_insufficient_length(st_out)
 
     return st_out
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -10,7 +10,6 @@ from pysep import logger
 from pysep.utils.fmt import get_codes
 
 
-
 def format_streams_for_rotation(st):
     """
     ObsPy requires specific channel naming to get stream rotation working.


### PR DESCRIPTION
- Add missing parameters to PySEP docstring
- Rewrite PySEP docstring parameter definitions for those that were lacking
- Categorize PySEP docstring parameters to make things easier to read
- Fixes some flag parameters not actually being used during PySEP processing
- Removes hard restriction of requiring event depth and magnitude when default event selection used
- Categorize RecSec dosctring to make things easier to read
- Removes unneeded function from RecSec script