### PR TITLE
Bugfix: unable to set event_depth_km or event_magnitude as NoneType

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -5,9 +5,6 @@ Python Seismogram Extraction and Processing (PySEP)
 Download, pre-process, and organize seismic waveforms, event and station
 metadata. Save waveforms as SAC files for use in moment tensor inversion and 
 adjoint tomography codes.
-
-:authors:
-
 """
 import argparse
 import os

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1845,10 +1845,20 @@ class RecordSection:
         # HYPO: If only one event, show hypocenter information
         if self.stats.nevents == 1:
             sac = self.st[0].stats.sac
+            # Accomodate unknown depth and magnitude
+            if "evdp" in sac:
+                evdp = f"{sac['evdp']:.2f}km"
+            else:
+                evdp = "None"
+            if "mag" in sac:
+                mag = f"M{sac['mag']:.2f}"
+            else:
+                mag = "None"
+
             # HYPO: lon, lat, depth, mag
             hypo = (
                 f"\nHYPO: ({sac['evlo']:.2f}{DEG}, {sac['evla']:.2f}{DEG}), " 
-                f"Z={sac['evdp']:.2f}km, M{sac['mag']:.2f}"
+                f"Z={evdp}, Mag={mag}"
             )
         else:
             hypo = ""

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -182,25 +182,12 @@ def _append_sac_headers_trace(tr, event, inv):
 
     otime = event.preferred_origin().time
 
-    # Allow for no magnitude and no depth information
-    try:
-        evdp = event.preferred_origin().depth / 1E3  # units: km
-    except Exception:  # NOQA
-        evdp = 999.9  # dummy value
-
-    try:
-        mag = event.preferred_magnitude().mag
-    except Exception: # NOQA
-        mag = 9999  # dummy value
-
     sac_header = {
         "iztype": 9,  # Ref time equivalence, IB (9): Begin time
         "b": tr.stats.starttime - event.preferred_origin().time,  # begin time
         "e": tr.stats.npts * tr.stats.delta,  # end time
         "evla": event.preferred_origin().latitude,
         "evlo": event.preferred_origin().longitude,
-        "evdp": evdp,
-        "mag": mag,
         "stla": sta.latitude,
         "stlo": sta.longitude,
         "stel": sta.elevation / 1E3,  # elevation in km
@@ -224,6 +211,19 @@ def _append_sac_headers_trace(tr, event, inv):
         sac_header["cmpinc"] = cha.dip  # channel dip/inclination in degrees
         sac_header["cmpaz"] = cha.azimuth  # channel azimuth in degrees
     except IndexError:
+        pass
+
+    # Allow for no magnitude and no depth information
+    try:
+        evdp = event.preferred_origin().depth / 1E3  # units: km
+        sac_header["evdp"] = evdp
+    except Exception:  # NOQA
+        pass
+
+    try:
+        mag = event.preferred_magnitude().mag
+        sac_header["mag"] = mag
+    except Exception:  # NOQA
         pass
 
     # Append SAC header and include back azimuth for rotation

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -269,6 +269,10 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
                                                     phase_list=phase_list)
     # Arrivals may return multiple entires for each phase, pick earliest
     for tr in st_out[:]:
+        # Missing SAC header values may cause certain or all stations to not 
+        # be present in the `phase_dict`
+        if tr.get_id() not in phase_dict:
+            continue
         arrivals = phase_dict[tr.get_id()]
         # If the TauP arrival calculation fails, `arrivals` will be empty
         if not arrivals:

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -46,8 +46,7 @@ def get_taup_arrivals_with_sac_headers(st, phase_list=None, model="ak135",):
     for tr in st:
         sac_header = tr.stats.sac
         if "evdp" not in sac_header or "gcarc" not in sac_header:
-            logger.debug(f"'evdp' or 'gcarc' not in sac header of {tr.get_id(), "
-                         "skipping")
+            logger.debug(f"skip {tr.get_id()} phase arr., no 'evdp' or 'gcarc")
             continue
         depth_km = sac_header["evdp"]  # units: km
         dist_deg = sac_header["gcarc"]

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -44,8 +44,13 @@ def get_taup_arrivals_with_sac_headers(st, phase_list=None, model="ak135",):
 
     logger.debug(f"fetching arrivals, phases {phase_list} and model '{model}'")
     for tr in st:
-        depth_km = tr.stats.sac["evdp"]  # units: km
-        dist_deg = tr.stats.sac["gcarc"]
+        sac_header = tr.stats.sac
+        if "evdp" not in sac_header or "gcarc" not in sac_header:
+            logger.debug(f"'evdp' or 'gcarc' not in sac header of {tr.get_id(), "
+                         "skipping")
+            continue
+        depth_km = sac_header["evdp"]  # units: km
+        dist_deg = sac_header["gcarc"]
         while True:
             try:
                 arrivals = taup_func(source_depth_in_km=depth_km,


### PR DESCRIPTION
- Address Issue: #71 
- Fixes bug in PySEP where parameters `event_depth_km` and `event_magnitude` were not being allowed because something in the intermediate processing steps would break
- Parts of the code that a required 'evdp' (event depth) in the SAC header included, which broke with NoneType depth:
    - Fetching TauP arrivals
    - SAC headers
    - record section titles
- Event magnitude required in:
    -  SAC headers
    - 'search' type event selection
    - record section titles
- The above functions now skip over depth or magnitude information when these are set as NoneType, or allow them through as NoneTypes