### PR TITLE
Feature recsec tmarks

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -47,7 +47,7 @@ from pysep.utils.process import (merge_and_trim_start_end_times, resample_data,
                                  format_streams_for_rotation, rotate_to_uvw,
                                  estimate_prefilter_corners)
 from pysep.utils.plot import plot_source_receiver_map
-from pysep.recsec import plotw_rs
+from pysep.recsec import RecordSection
 
 
 class Pysep:
@@ -1452,8 +1452,6 @@ class Pysep:
     def plot(self):
         """
         Plot map and record section if requested
-
-        TODO improve source receiver map plotting
         """
         if "map" in self.plot_files or "all" in self.plot_files:
             logger.info("plotting source receiver map")
@@ -1463,8 +1461,10 @@ class Pysep:
         if "record_section" in self.plot_files or "all" in self.plot_files:
             fid = os.path.join(self.output_dir, f"record_section.png")
             # Default settings to create a general record section
-            plotw_rs(st=self.st, sort_by="distance_r", scale_by="normalize",
-                     overwrite=True, show=False, save=fid)
+            rs = RecordSection(st=self.st, sort_by="distance",
+                               scale_by="normalize", overwrite=True, show=False,
+                               save=fid)
+            rs.run()
 
     def _event_tag_and_output_dir(self):
         """
@@ -1563,7 +1563,6 @@ class Pysep:
         # Rotation to various orientations. The output stream will have ALL
         # components, both rotated and non-rotated
         if self.rotate is not None:
-            import pdb;pdb.set_trace()
             self.st = self.rotate_streams()
 
         # Final quality checks on ALL waveforms before we write them out

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1565,7 +1565,7 @@ class RecordSection:
         c = self.kwargs.get("tmark_c", "r")
         lw = self.kwargs.get("tmark_lw", 1.5)
         ls = self.kwargs.get("tmark_ls", "-")
-        alpha = self.kwargs.get("tmark_alpha", 1.)
+        alpha = self.kwargs.get("tmark_alpha", 0.75)
         z = self.kwargs.get("tmark_zorder", 5)
 
         for tmark in self.tmarks:
@@ -2113,19 +2113,9 @@ def plotw_rs(*args, **kwargs):
         rs.plot()
     # More complicated case where we need to split onto multiple pages
     else:
-        if "_r" in rs.sort_by:
-            # !!! This doesn't work, start comes before stop or something
-            rnge = np.arange(len(rs.st), 0, -1 * rs.max_traces_per_rs)
-            if (rnge[0] - rnge[1]) < rs.max_traces_per_rs:
-                rnge = np.insert(rnge, 0, len(rs.st))
-        else:
-            rnge = np.arange(0, len(rs.st), rs.max_traces_per_rs)
-            # Case where the num waveforms is less than max_traces_per_rs,
-            # ensure that the last page contains the remainder
-            if (rnge[-1] - rnge[-2]) < rs.max_traces_per_rs:
-                rnge = np.append(rnge, len(rs.st))
-
-        for i, start in enumerate(rnge):
+        for i, start in enumerate(
+                np.arange(0, len(rs.st), rs.max_traces_per_rs)
+        ):
             stop = start + rs.max_traces_per_rs
             if stop < rs.max_traces_per_rs:
                 stop = len(rs.st)


### PR DESCRIPTION
Addresses Issue #70

Adds feature `tmarks` which allows for setting vertical lines at certain time values. These lines do **not** take time shift or move out into account, they simple plot lines at reference times. It can be implemented via recsec on the command line

```bash
recsec --tmarks 0 100 200
```

or via scripting:

```python
RecordSection(tmarks=[0, 100, 200]...)  # units: seconds
```
Keyword arguments can be used to control the look of the tmark lines. Check function `recsec.RecordSection._plot_tmarks()` for available keyword arguments.

