### PR TITLE
Feature: fill data gaps and bug fix trim start end times

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -57,6 +57,7 @@ class Pysep:
                  remove_clipped=False, remove_insufficient_length=True,
                  water_level=60, detrend=True, demean=True, taper_percentage=0,
                  rotate=None, pre_filt="default", fill_data_gaps=None,
+                 gap_fration=1.,
                  mindistance=0, maxdistance=20E3, minazimuth=0, maxazimuth=360,
                  minlatitude=None, minlongitude=None, maxlatitude=None,
                  maxlongitude=None, resample_freq=None, scale_factor=1,
@@ -232,6 +233,13 @@ class Pysep:
             - 'latest': fill with the last value of pre-gap data
             - NoneType: do not fill data gaps, which will lead to stations w/
             data gaps being removed.
+        :type gap_fraction: float
+        :param gap_fraction: if `fill_data_gaps` is not None, determines the
+            maximum allowable fraction (percentage) of data that gaps can
+            comprise. For example, a value of 0.3 means that 30% of the data
+            (in samples) can be gaps that will be filled by `fill_data_gaps`.
+            Traces with gap fractions that exceed this value will be removed.
+            Defaults to 1. (100%) of data can be gaps.
 
         .. note::
             Data processing parameters
@@ -445,6 +453,7 @@ class Pysep:
         self.remove_clipped = bool(remove_clipped)
         self.remove_insufficient_length = remove_insufficient_length
         self.fill_data_gaps = fill_data_gaps
+        self.gap_fraction = gap_fraction
 
         # Program related parameters
         self.output_dir = output_dir or os.getcwd()
@@ -1133,7 +1142,8 @@ class Pysep:
 
         # Remove data gaps, ensure that all traces have the same start and end
         st_out = merge_and_trim_start_end_times(
-            st_out, fill_value=self.fill_data_gaps
+            st_out, fill_value=self.fill_data_gaps,
+            gap_fraction=self.gap_fraction
         )
 
         return st_out

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -56,7 +56,7 @@ class Pysep:
                  event_magnitude=None, remove_response=True,
                  remove_clipped=False, remove_insufficient_length=True,
                  water_level=60, detrend=True, demean=True, taper_percentage=0,
-                 rotate=None, pre_filt="default", fill_data_gaps=None,
+                 rotate=None, pre_filt="default", fill_data_gaps=False,
                  gap_fraction=1.,
                  mindistance=0, maxdistance=20E3, minazimuth=0, maxazimuth=360,
                  minlatitude=None, minlongitude=None, maxlatitude=None,
@@ -216,9 +216,9 @@ class Pysep:
         :param remove_insufficient_length: remove waveforms whose trace length
             does not match the average (mode) trace length in the stream.
             Defaults to True
-        :type fill_data_gaps: str or int or float
+        :type fill_data_gaps: str or int or float or bool
         :param fill_data_gaps: How to deal with data gaps (missing sections of
-            waveform over a continuous time span). NoneType by default, which
+            waveform over a continuous time span). False by default, which
             means data with gaps are removed completely. Users who want access
             to data with gaps must choose how gaps are filled. See API for
             ObsPy.core.stream.Stream.merge() for how merge is handled:
@@ -231,7 +231,7 @@ class Pysep:
             - 'interpolate': linearly interpolate from the last value pre-gap
             to the first value post-gap
             - 'latest': fill with the last value of pre-gap data
-            - NoneType: do not fill data gaps, which will lead to stations w/
+            - False: do not fill data gaps, which will lead to stations w/
             data gaps being removed.
 
             NOTE: Be careful about data types, as there are no checks that the

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -233,6 +233,10 @@ class Pysep:
             - 'latest': fill with the last value of pre-gap data
             - NoneType: do not fill data gaps, which will lead to stations w/
             data gaps being removed.
+
+            NOTE: Be careful about data types, as there are no checks that the
+            fill value matches the internal data types. This may cause
+            unexpected errors.
         :type gap_fraction: float
         :param gap_fraction: if `fill_data_gaps` is not None, determines the
             maximum allowable fraction (percentage) of data that gaps can

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1154,6 +1154,11 @@ class Pysep:
             endtime=self.origin_time + self.seconds_after_ref
         )
 
+        if not st_out:
+            logger.critical("preprocessing removed all traces from Stream, "
+                            "cannot proceed")
+            sys.exit(-1)
+
         return st_out
 
     def _remove_response_llnl(self, st):
@@ -1278,7 +1283,6 @@ class Pysep:
                         logger.debug(f"rotate error: {e}")
                         continue
                     st_out += _st
-            import pdb;pdb.set_trace()
             # Check to see if rotation errors kicked out all stations
             if not st_out:
                 logger.critical("rotation errors have reduced Stream to len 0, "

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1167,10 +1167,11 @@ class Pysep:
                                    gap_fraction=self.gap_fraction)
 
         # Ensure that all traces have the same start and end
-        st_out = trim_start_end_times(
-            st_out,  starttime=self.origin_time - self.seconds_before_ref,
-            endtime=self.origin_time + self.seconds_after_ref
-        )
+        if self.origin_time:
+            st_out = trim_start_end_times(
+                st_out,  starttime=self.origin_time - self.seconds_before_ref,
+                endtime=self.origin_time + self.seconds_after_ref
+            )
 
         if not st_out:
             logger.critical("preprocessing removed all traces from Stream, "

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -8,7 +8,7 @@ Test the preprocessing functions which include standardization and rotation
 import pytest
 import random
 import numpy as np
-from obspy import read, read_events, read_inventory
+from obspy import read, read_events, read_inventory, Stream
 
 from pysep import logger, Pysep
 from pysep.utils.cap_sac import append_sac_headers
@@ -52,6 +52,23 @@ def test_merge_and_trim_start_end_times(test_st):
     """
     st = merge_and_trim_start_end_times(test_st)
     assert(len(test_st) - len(st) == 4)
+
+
+def test_merge_data_gaps(test_st):
+    """
+    Make sure merging data gaps works for a few different options. Does not
+    check values, just runs through the function
+    """
+    # ATKA already has gappy data on components E and Z
+    st_gap = test_st.select(station="ATKA")
+    assert(len(st_gap) == 5)
+
+    for fill_value in [None, "mean", "interpolate", "latest", 0, 5.5]:
+        st = merge_and_trim_start_end_times(st_gap, fill_value=fill_value)
+        if fill_value is None:
+            assert(len(st) == 1)  # removed E and N from stations
+        else:
+            assert(len(st) != 0)  # did not remove
 
 
 def test_resample_data(test_st):

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -59,16 +59,27 @@ def test_merge_data_gaps(test_st):
     Make sure merging data gaps works for a few different options. Does not
     check values, just runs through the function
     """
-    # ATKA already has gappy data on components E and Z
+    # ATKA already has gappy data on components E and N
     st_gap = test_st.select(station="ATKA")
     assert(len(st_gap) == 5)
 
     for fill_value in [None, "mean", "interpolate", "latest", 0, 5.5]:
         st = merge_and_trim_start_end_times(st_gap, fill_value=fill_value)
-        if fill_value is None:
+        if fill_value in [None, 5.5]:
             assert(len(st) == 1)  # removed E and N from stations
         else:
-            assert(len(st) != 0)  # did not remove
+            assert(len(st) == 3)  # successful merge
+
+
+def test_merge_data_gap_fraction(test_st):
+    """Try out the fraction percentage function"""
+    # ATKA already has gappy data on components E and N
+    st_gap = test_st.select(station="ATKA")
+    assert(len(st_gap) == 5)
+
+    st = merge_and_trim_start_end_times(st_gap, fill_value=0,
+                                        gap_fraction=0.01)
+    assert(len(st) == 1)
 
 
 def test_resample_data(test_st):

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -12,7 +12,7 @@ from obspy import read, read_events, read_inventory, Stream
 
 from pysep import logger, Pysep
 from pysep.utils.cap_sac import append_sac_headers
-from pysep.utils.process import (merge_and_trim_start_end_times,
+from pysep.utils.process import (merge_gapped_data, trim_start_end_times,
                                  resample_data, format_streams_for_rotation,
                                  rotate_to_uvw, append_back_azimuth_to_stats)
 
@@ -45,12 +45,12 @@ def test_st(test_event, test_inv):
     return st
 
 
-def test_merge_and_trim_start_end_times(test_st):
+def test_trim_start_end_times(test_st):
     """
     Make sure we can trim per-station waveforms to their shortest component
     and also merge existing waveforms, dropping those with data gaps
     """
-    st = merge_and_trim_start_end_times(test_st)
+    st = trim_start_end_times(test_st)
     assert(len(test_st) - len(st) == 4)
 
 
@@ -64,7 +64,7 @@ def test_merge_data_gaps(test_st):
     assert(len(st_gap) == 5)
 
     for fill_value in [None, "mean", "interpolate", "latest", 0, 5.5]:
-        st = merge_and_trim_start_end_times(st_gap, fill_value=fill_value)
+        st = merge_gapped_data(st_gap, fill_value=fill_value)
         if fill_value in [None, 5.5]:
             assert(len(st) == 1)  # removed E and N from stations
         else:
@@ -77,8 +77,7 @@ def test_merge_data_gap_fraction(test_st):
     st_gap = test_st.select(station="ATKA")
     assert(len(st_gap) == 5)
 
-    st = merge_and_trim_start_end_times(st_gap, fill_value=0,
-                                        gap_fraction=0.01)
+    st = merge_gapped_data(st_gap, fill_value=0, gap_fraction=0.01)
     assert(len(st) == 1)
 
 

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -219,7 +219,7 @@ def test_get_usgs_moment_tensor():
     """
     event = test_get_gcmt_moment_tensor()
     del event.focal_mechanisms
-
+    pytest.set_trace()
     cat = get_usgs_moment_tensor(event=event)
     assert(len(cat) == 1)
     event = cat[0]

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -226,7 +226,6 @@ def trim_start_end_times(st, starttime=None, endtime=None):
     if endtime is None:
         endtime = min([tr.stats.endtime for tr in st_edit])
 
-    import pdb;pdb.set_trace()
     st_edit.trim(starttime=starttime, endtime=endtime)
 
     return st_edit

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -226,6 +226,7 @@ def trim_start_end_times(st, starttime=None, endtime=None):
     if endtime is None:
         endtime = min([tr.stats.endtime for tr in st_edit])
 
+    import pdb;pdb.set_trace()
     # Go through all stations and warn and remove about traces that are shorter
     # than given start and end times
     for tr in st_edit:
@@ -270,7 +271,7 @@ def merge_gapped_data(st, fill_value=None, gap_fraction=1.):
         - 'interpolate': linearly interpolate from the last value pre-gap
         to the first value post-gap
         - 'latest': fill with the last value of pre-gap data
-        - NoneType: do not fill data gaps, which will lead to stations w/
+        - False: do not fill data gaps, which will lead to stations w/
         data gaps being removed.
     :type gap_fraction: float
     :param gap_fraction: if `fill_data_gaps` is not None, determines the
@@ -301,13 +302,13 @@ def merge_gapped_data(st, fill_value=None, gap_fraction=1.):
             fillval = fill_value  # dummy value to allow in-place changes
 
             # Check if there are data gaps that we need to address
-            if data_gaps and fill_value is not None:
+            if data_gaps and fill_value is not False:
                 # Determine the percentage of data that comprises gaps
                 gap_duration_samp = data_gaps[0][-1]  # assuming only one set
                 starttime = min([tr.stats.starttime for tr in st_edit_select])
                 endtime = max([tr.stats.endtime for tr in st_edit_select])
-                total_samps = (endtime - starttime) / \
-                                            st_edit_select[0].stats.delta
+                total_samps = \
+                    (endtime - starttime) / st_edit_select[0].stats.delta
 
                 gap_percentage = gap_duration_samp / total_samps
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -208,7 +208,9 @@ def rotate_to_uvw(st):
 
 def trim_start_end_times(st, starttime=None, endtime=None):
     """
-    Trim all traces in a Stream to a unfirom start and end times
+    Trim all traces in a Stream to a uniform start and end times. If no 
+    `starttime` or `endtime` are provided, they are selected as the outer 
+    bounds of the Streams time bounds.
 
     :type st: obspy.core.stream.Stream
     :param st: stream to merge and trim start and end times for
@@ -222,9 +224,9 @@ def trim_start_end_times(st, starttime=None, endtime=None):
     st_edit = st.copy()
 
     if starttime is None:
-        starttime = max([tr.stats.starttime for tr in st_edit])
+        starttime = min([tr.stats.starttime for tr in st_edit])
     if endtime is None:
-        endtime = min([tr.stats.endtime for tr in st_edit])
+        endtime = max([tr.stats.endtime for tr in st_edit])
 
     # Go through all stations and warn and remove about traces that are shorter
     # than given start and end times

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -219,8 +219,37 @@ def merge_and_trim_start_end_times(st, fill_value=None, gap_fraction=1.):
         are NOT intended functionalities, so we replace the old 'interpolate'
         function with a trim.
 
+    .. note::
+        Be careful about `fill_value` data types, as there are no checks that
+        the fill value matches the internal data types. This may cause
+        unexpected errors.
+
     :type st: obspy.core.stream.Stream
     :param st: stream to merge and trim start and end times for
+    :type fill_value: str or int or float
+    :param fill_value: How to deal with data gaps (missing sections of
+        waveform over a continuous time span). NoneType by default, which
+        means data with gaps are removed completely. Users who want access
+        to data with gaps must choose how gaps are filled. See API for
+        ObsPy.core.stream.Stream.merge() for how merge is handled:
+
+        Options include:
+
+        - 'mean': fill with the mean of all data values in the gappy data
+        - <int or float>: fill with a constant, user-defined value, e.g.,
+        0 or 1.23 or 9.999
+        - 'interpolate': linearly interpolate from the last value pre-gap
+        to the first value post-gap
+        - 'latest': fill with the last value of pre-gap data
+        - NoneType: do not fill data gaps, which will lead to stations w/
+        data gaps being removed.
+    :type gap_fraction: float
+    :param gap_fraction: if `fill_data_gaps` is not None, determines the
+        maximum allowable fraction (percentage) of data that gaps can
+        comprise. For example, a value of 0.3 means that 30% of the data
+        (in samples) can be gaps that will be filled by `fill_data_gaps`.
+        Traces with gap fractions that exceed this value will be removed.
+        Defaults to 1. (100%) of data can be gaps.
     :rtype: obspy.core.stream.Stream
     :return: Stream that has been trimmed
     """

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -226,10 +226,10 @@ def trim_start_end_times(st, starttime=None, endtime=None):
     if endtime is None:
         endtime = min([tr.stats.endtime for tr in st_edit])
 
-    import pdb;pdb.set_trace()
     # Go through all stations and warn and remove about traces that are shorter
     # than given start and end times
     for tr in st_edit:
+        remove = False
         if tr.stats.starttime > starttime:
             logger.warning(f"{tr.get_id()} has too late of a starttime, remove")
             remove = True

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -226,6 +226,18 @@ def trim_start_end_times(st, starttime=None, endtime=None):
     if endtime is None:
         endtime = min([tr.stats.endtime for tr in st_edit])
 
+    # Go through all stations and warn and remove about traces that are shorter
+    # than given start and end times
+    for tr in st_edit:
+        if tr.stats.starttime > starttime:
+            logger.warning(f"{tr.get_id()} has too late of a starttime, remove")
+            remove = True
+        elif tr.stats.endtime < endtime:
+            logger.warning(f"{tr.get_id()} has too early of an endtime, remove")
+            remove = True
+        if remove:
+            st_edit.remove(tr)
+
     st_edit.trim(starttime=starttime, endtime=endtime)
 
     return st_edit

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -220,10 +220,13 @@ def trim_start_end_times(st, starttime=None, endtime=None):
         the minimum endtime in entire stream
     """
     st_edit = st.copy()
+
     if starttime is None:
         starttime = max([tr.stats.starttime for tr in st_edit])
     if endtime is None:
         endtime = min([tr.stats.endtime for tr in st_edit])
+
+    import pdb;pdb.set_trace()
     st_edit.trim(starttime=starttime, endtime=endtime)
 
     return st_edit
@@ -324,10 +327,13 @@ def merge_gapped_data(st, fill_value=None, gap_fraction=1.):
             logger.warning(f"{code} merge error: {e}")
             continue
 
-        for tr in st_edit_select:
-            if np.ma.is_masked(tr.data):
-                logger.warning(f"{tr.get_id()} has data gaps, removing")
-                st_edit_select.remove(tr)
+        st_out += st_edit_select
+
+    # One last check for data gaps
+    for tr in st_out:
+        if np.ma.is_masked(tr.data):
+            logger.warning(f"{tr.get_id()} has data gaps, removing")
+            st_out.remove(tr)
 
     return st_out
 


### PR DESCRIPTION
Addresses Issues #83 and #67 dealing with gappy data and waveform start and end times.

In current version of PySEP, gapped data is not handled, any data with gaps is thrown own during preprocessing.
Additionally, waveforms are gathered from data centers directly on the requested bounds (+/- s around origin time), which may cause saved data to be shorter than expected due to time series being slightly truncated during rotation, resampling or other preprocessing steps.

This PR addresses these issues by:
- Introduce parameters `fill_data_gaps` and `gap_fraction` to address data gaps
- By default `fill_data_gaps` is False, which handles gapped data like the current code, by removing stations with gaps
- `fill_data_gaps` can also be a series of values which tell PySEP to keep gapped data, and how to deal with data gaps (see: https://docs.obspy.org/packages/autogen/obspy.core.stream.Stream.merge.html and PySEP class docstring)
- `gap_fraction` tells PySEP what allowable fraction of data can be data gaps. Defaults to 1. (100% of data can be gaps). This lets Users allow in short or long data gaps depending on their use.
- New hidden parameter `extra_download_pct` handles waveform start and end time by adding a small time buffer around downloaded data (default 1%). This is then trimmed off during preprocessing, to help ensure that all Traces in the Stream have the same start and end time.

Under the hood:
- Preprocessing function `merge_and_trim_start_end_times` has been split into `merge_gapped_data` (to handle merging) and `trim_start_end_times` (to handle data trimming)
- Adds tests to cover these new functionality
- Adds docstrings in PySEP class to describe the available options for the new parameters
- Adds in minor checks during workflow to ensure parameters are set correctly.