### PR TITLE
Bugfix: stations removed insufficient time 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,4 +32,8 @@
 	- New hidden parameter `extra_download_pct` handles waveform start and end time 
 	- Resampling now occurs before trace start and end time trimming
 - Bugfix: bulk query request locations was incorrectly hardocded as a wildcard
+- Waveform start and end trim now performed trace by trace with option to fill
+  empty boundaries with `fill_data_gaps`
+- Introduce new parameter `remove_masked_data` which is a toggle flag to remove
+  data which has been merged with no fill value. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # PySEP Changelog
 
-## Version 0.2.0 (Master)
+## Version 0.2.0 
 
 - RecSec plot aesthetics altered to provide more information efficiently  
 - Shifted documentation to GitHub Wiki page
 - Added moment tensor gathering routines from Pyatoa
 
-## Version 0.3.0 (Devel)
+## Version 0.3.0 
 
 - Removed llnl_db_client dependency from package and made it optional 
 - Re-instated 'mass_downloader' option 
@@ -17,3 +17,19 @@
 - Removed hard restriction on requiring event depth and magnitude for default event selection
 - Add feature 'tmarks' to record section to plot vertical lines at reference times
 - Fix ordering of multi-page record sections when using plotw_rs 
+
+## Version 0.3.1 (Master)
+
+- Renames package pysep->pysep-adjtomo (only relevant for PyPi, everything in the package remains PySEP)
+- Removes llnl_db_client as a dependency of PySEP (PyPi does not allow unpublished dependencies, i.e., via GitHub)
+- Adds MANIFEST.in file to retain example config files during source code building and packaging
+
+
+## Version 0.3.2 (Devel)
+
+- #81, #84
+	- Introduce parameters `fill_data_gaps` and `gap_fraction` to address data gaps
+	- New hidden parameter `extra_download_pct` handles waveform start and end time 
+	- Resampling now occurs before trace start and end time trimming
+- Bugfix: bulk query request locations was incorrectly hardocded as a wildcard
+

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -55,6 +55,7 @@ class Pysep:
                  event_latitude=None, event_longitude=None, event_depth_km=None,
                  event_magnitude=None, remove_response=True,
                  remove_clipped=False, remove_insufficient_length=True,
+                 remove_masked_data=True,
                  water_level=60, detrend=True, demean=True, taper_percentage=0,
                  rotate=None, pre_filt="default", fill_data_gaps=False,
                  gap_fraction=1.,
@@ -224,6 +225,12 @@ class Pysep:
         :param remove_insufficient_length: remove waveforms whose trace length
             does not match the average (mode) trace length in the stream.
             Defaults to True
+        :type remove_masked_data: bool
+        :param remove_masked_data: If `fill_data_gaps` is False or None, data
+            with gaps that go through the merge process will contain masked
+            arrays (essentially retaining gaps). By default, PySEP will remove
+            these data during processing. To keep this data, set
+            `remove_masked_data` == True.
         :type fill_data_gaps: str or int or float or bool
         :param fill_data_gaps: How to deal with data gaps (missing sections of
             waveform over a continuous time span). False by default, which
@@ -1183,7 +1190,6 @@ class Pysep:
                 endtime=self.origin_time + self.seconds_after_ref,
                 fill_value=self.fill_data_gaps
             )
-        import pdb;pdb.set_trace()
         if not st_out:
             logger.critical("preprocessing removed all traces from Stream, "
                             "cannot proceed")

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -414,8 +414,10 @@ class Pysep:
             self.origin_time = UTCDateTime(origin_time)
         except TypeError:
             self.origin_time = None
-        self.seconds_before_event = seconds_before_event
-        self.seconds_after_event = seconds_after_event
+
+        # Force float type to avoid rounding errors
+        self.seconds_before_event = float(seconds_before_event)
+        self.seconds_after_event = float(seconds_after_event)
 
         # Optional: if User wants to define an event on their own.
         # `event_depth_km` and `event_magnitude` are also used for client query

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -416,8 +416,8 @@ class Pysep:
             self.origin_time = None
 
         # Force float type to avoid rounding errors
-        self.seconds_before_event = float(seconds_before_event)
-        self.seconds_after_event = float(seconds_after_event)
+        self.seconds_before_event = seconds_before_event
+        self.seconds_after_event = seconds_after_event
 
         # Optional: if User wants to define an event on their own.
         # `event_depth_km` and `event_magnitude` are also used for client query
@@ -434,6 +434,7 @@ class Pysep:
 
         # Waveform collection parameters
         self.reference_time = reference_time or self.origin_time
+        # Force float type to avoid rounding errors
         self.seconds_before_ref = seconds_before_ref
         self.seconds_after_ref = seconds_after_ref
         self.phase_list = phase_list
@@ -623,6 +624,12 @@ class Pysep:
         if self.use_mass_download is True:
             logger.info("will use option `mass_download`, ignoring `client` "
                         "and downloading data from all available data centers")
+
+        # Force all time boundaries to be floats to avoid rounding errors
+        self.seconds_before_ref = float(self.seconds_before_ref)
+        self.seconds_after_ref = float(self.seconds_after_ref)
+        self.seconds_before_event = float(self.seconds_before_event)
+        self.seconds_after_event = float(self.seconds_after_event)
 
     def get_client(self):
         """
@@ -1173,9 +1180,10 @@ class Pysep:
         if self.origin_time:
             st_out = trim_start_end_times(
                 st_out,  starttime=self.origin_time - self.seconds_before_ref,
-                endtime=self.origin_time + self.seconds_after_ref
+                endtime=self.origin_time + self.seconds_after_ref,
+                fill_value=self.fill_data_gaps
             )
-
+        import pdb;pdb.set_trace()
         if not st_out:
             logger.critical("preprocessing removed all traces from Stream, "
                             "cannot proceed")

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -36,6 +36,7 @@ from pysep.utils.cap_sac import (append_sac_headers, write_cap_weights_files,
 from pysep.utils.curtail import (curtail_by_station_distance_azimuth,
                                  quality_check_waveforms_before_processing,
                                  quality_check_waveforms_after_processing,
+                                 remove_traces_w_masked_data
                                  )
 from pysep.utils.fmt import format_event_tag, format_event_tag_legacy, get_codes
 from pysep.utils.io import read_yaml, read_event_file, write_pysep_stations_file
@@ -476,6 +477,7 @@ class Pysep:
         self.resample_freq = resample_freq
         self.remove_clipped = bool(remove_clipped)
         self.remove_insufficient_length = remove_insufficient_length
+        self.remove_masked_data = remove_masked_data
         self.fill_data_gaps = fill_data_gaps
         self.gap_fraction = gap_fraction
 
@@ -1190,6 +1192,10 @@ class Pysep:
                 endtime=self.origin_time + self.seconds_after_ref,
                 fill_value=self.fill_data_gaps
             )
+        # Merging or trimming may introduce masked data, may remove from Stream
+        if self.remove_masked_data:
+            st_out = remove_traces_w_masked_data(st_out)
+
         if not st_out:
             logger.critical("preprocessing removed all traces from Stream, "
                             "cannot proceed")

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -66,6 +66,7 @@ def test_merge_data_gaps(test_st):
     for fill_value in [None, "mean", "interpolate", "latest", 0, 5.5]:
         st = merge_gapped_data(st_gap, fill_value=fill_value)
         if fill_value in [None, 5.5]:
+            pytest.set_trace()
             assert(len(st) == 1)  # removed E and N from stations
         else:
             assert(len(st) == 3)  # successful merge
@@ -78,7 +79,7 @@ def test_merge_data_gap_fraction(test_st):
     assert(len(st_gap) == 5)
 
     st = merge_gapped_data(st_gap, fill_value=0, gap_fraction=0.01)
-    assert(len(st) == 1)
+    assert(len(st) == 3)
 
 
 def test_resample_data(test_st):

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -182,7 +182,7 @@ def test_rotate_streams(test_st, test_inv, test_event):
     """
     Ensure that stream rotation works as expected after we format SAC headers
     """
-    sep = Pysep(log_level="CRITICAL", rotate=["ZNE", "RTZ"])
+    sep = Pysep(log_level="DEBUG", rotate=["ZNE", "RTZ"])
     for tr in test_st:
         del tr.stats.back_azimuth
     assert("back_azimuth" not in test_st[0].stats)

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -12,6 +12,7 @@ from obspy import read, read_events, read_inventory, Stream
 
 from pysep import logger, Pysep
 from pysep.utils.cap_sac import append_sac_headers
+from pysep.utils.curtail import remove_traces_w_masked_data
 from pysep.utils.process import (merge_gapped_data, trim_start_end_times,
                                  resample_data, format_streams_for_rotation,
                                  rotate_to_uvw, append_back_azimuth_to_stats)
@@ -65,8 +66,8 @@ def test_merge_data_gaps(test_st):
 
     for fill_value in [None, "mean", "interpolate", "latest", 0, 5.5]:
         st = merge_gapped_data(st_gap, fill_value=fill_value)
+        st = remove_traces_w_masked_data(st)
         if fill_value in [None, 5.5]:
-            pytest.set_trace()
             assert(len(st) == 1)  # removed E and N from stations
         else:
             assert(len(st) == 3)  # successful merge
@@ -79,7 +80,8 @@ def test_merge_data_gap_fraction(test_st):
     assert(len(st_gap) == 5)
 
     st = merge_gapped_data(st_gap, fill_value=0, gap_fraction=0.01)
-    assert(len(st) == 3)
+    st = remove_traces_w_masked_data(st)
+    assert(len(st) == 1)
 
 
 def test_resample_data(test_st):

--- a/pysep/utils/curtail.py
+++ b/pysep/utils/curtail.py
@@ -265,9 +265,8 @@ def remove_stations_for_insufficient_length(st):
     expected_length = vals[np.argmax(counts)]
     logger.debug(f"assuming that the expected stream length is: "
                  f"{expected_length}s")
-
     for tr, length in zip(st_out[:], stream_lengths):
-        if length <= expected_length:
+        if length < expected_length:
             logger.debug(f"{tr.get_id()} has unexpected time length of "
                          f"{length}s, removing")
             st_out.remove(tr)

--- a/pysep/utils/curtail.py
+++ b/pysep/utils/curtail.py
@@ -253,7 +253,6 @@ def remove_stations_for_insufficient_length(st):
     logger.debug(f"assuming that the expected stream length is: "
                  f"{expected_length}s")
 
-    import pdb;pdb.set_trace()
     for tr, length in zip(st_out[:], stream_lengths):
         if length <= expected_length:
             logger.debug(f"{tr.get_id()} has unexpected time length of "
@@ -309,7 +308,6 @@ def subset_streams(st_a, st_b):
                  f"{len(sta_ids_a) - len(common_ids)} traces from `st_a`")
     logger.debug(f"stream subset removes "
                  f"{len(sta_ids_b) - len(common_ids)} traces from `st_b`")
-
 
     for station_id in common_ids:
         net, sta, loc, comp = station_id.split(".")

--- a/pysep/utils/curtail.py
+++ b/pysep/utils/curtail.py
@@ -253,9 +253,10 @@ def remove_stations_for_insufficient_length(st):
     logger.debug(f"assuming that the expected stream length is: "
                  f"{expected_length}s")
 
+    import pdb;pdb.set_trace()
     for tr, length in zip(st_out[:], stream_lengths):
-        if length != expected_length:
-            logger.debug(f"{tr.get_id()} has insufficient time length of "
+        if length <= expected_length:
+            logger.debug(f"{tr.get_id()} has unexpected time length of "
                          f"{length}s, removing")
             st_out.remove(tr)
 

--- a/pysep/utils/curtail.py
+++ b/pysep/utils/curtail.py
@@ -98,8 +98,8 @@ def quality_check_waveforms_before_processing(st, remove_clipped=True):
     return st_out
 
 
-def quality_check_waveforms_after_processing(
-        st, remove_insufficient_length=True, remove_masked_data=True):
+def quality_check_waveforms_after_processing(st,
+                                             remove_insufficient_length=True):
     """
     Quality assurance to deal with bad data after preprocessing, because
     preprocesing step will merge, filter and rotate data.
@@ -110,17 +110,11 @@ def quality_check_waveforms_after_processing(
     :type remove_insufficient_length: bool
     :param remove_insufficient_length: boolean flag to turn on/off insufficient
         length checker
-    :type remove_masked_data: bool
-    :param remove_masked_data: remove traces that have masked data which is
-        created when you merge data that has data gaps without filling the gaps
     """
     st_out = st.copy()
 
     if remove_insufficient_length:
         st_out = remove_stations_for_insufficient_length(st_out)
-
-    if remove_masked_data:
-        st_out = remove_traces_w_masked_data(st)
 
     return st_out
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -206,7 +206,7 @@ def rotate_to_uvw(st):
     return st_out
 
 
-def trim_start_end_times(st, starttime=None, endtime=None):
+def trim_start_end_times(st, starttime=None, endtime=None, fill_value=None):
     """
     Trim all traces in a Stream to a uniform start and end times. If no 
     `starttime` or `endtime` are provided, they are selected as the outer 
@@ -241,7 +241,8 @@ def trim_start_end_times(st, starttime=None, endtime=None):
         if remove:
             st_edit.remove(tr)
 
-    st_edit.trim(starttime=starttime, endtime=endtime)
+    st_edit.trim(starttime=starttime, endtime=endtime, nearest_sample=False,
+                 fill_value=fill_value)
 
     return st_edit
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -255,7 +255,7 @@ def trim_start_end_times(st, starttime=None, endtime=None, fill_value=None):
                     _fillval = np.nanmean(tr.data).astype(tr.data.dtype)
                 else:
                     _fillval = fill_value
-                    
+
                 logger.info(f"{tr.get_id()} filling start/endtime data gap w/: "
                             f"{_fillval}")
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -344,12 +344,6 @@ def merge_gapped_data(st, fill_value=None, gap_fraction=1.):
 
         st_out += st_edit_select
 
-    # One last check for data gaps
-    for tr in st_out:
-        if np.ma.is_masked(tr.data):
-            logger.warning(f"{tr.get_id()} has data gaps, removing")
-            st_out.remove(tr)
-
     return st_out
 
 


### PR DESCRIPTION
Related to #67 and #83 

Stations with data gaps at the beginning of end of a trace (that is there is no data at the requested starttime or at the requested endtime) was being removed because ObsPy's Trace.merge() feature (which was being used to fill data gaps), does not address these boundary times.

To retain these stations, the trim (https://docs.obspy.org/packages/autogen/obspy.core.stream.Stream.trim.html) function now fills data gaps of these boundary times.

Changelog:
- Forces `seconds_*_ref`, `seconds_*_event` to be of type float in the Pysep.check() function. Before they were allowed to set as integer which caused floating point rounding errors and trace length inconsistency
- During the trim operation (cutting start and end time), allow User to fill data gaps at the boundaries of time series using parameter `fill_data_gaps`. Values 'interpolate' and 'latest' and **not** available for function trim(), and if these are given to fill data gaps, then the trim operation defaults to mode 'mean'. 
- Added flag `remove_masked_data` to toggle on or off the removal of masked data arrays (which occur during merge operations that are not meant to fill data gaps). By default this is turned on (to match current behavior)
- The remove for insufficient data length function has been changed to check for traces with less samples than the mode value, rather than for equality. This is less restrictive and should allow more data through