### PR TITLE
Bugfix: plotw_rs sort order and multi-page order

### DIFF
--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1763,6 +1763,9 @@ class RecordSection:
             - y_axis: Place labels along the y-axis (left side of the figure)
                 Will replace the actual y-tick labels so not applicable for
                 absolute sorting which requries the y-axis labels
+            - y_axis_abs: for absolute plotting, place waveform labels to the
+                left side of the figure (outside border), co-existing with
+                y-axis labels
             - y_axis_right: same as `y_axis` but set on the right side of figure
             - x_min: Place labels on the waveforms at the minimum x value
             - x_max: Place labels on the waveforms at the maximum x value
@@ -1848,7 +1851,7 @@ class RecordSection:
                 va = "center"
                 func = min
                 x_val = func(self.stats.xmin)
-                plt.text(.01, .99, y_fmt, ha=ha, va=va,
+                plt.text(0, .99, y_fmt, ha=ha, va=va,
                          transform=self.ax.transAxes, fontsize=fontsize)
 
             if self.xlim_s is not None:

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -198,9 +198,11 @@ class RecordSection:
             - 'backazimuth': sort by source-receiver backazimuth (deg) with
                 constant vertical spacing. Requires `azimuth_start_deg`
             - 'distance': sort by source-receiver distance (km) with constant
-                vertical spacing. Requires `distance_units`
+                vertical spacing. Smallest distances at the top of the figure.
+                 Requires `distance_units`
             - 'abs_distance': absolute vertical spacing of waveforms defined by
-                source-receiver distance. Requires `distance_units`
+                source-receiver distance. Smallest distance at the top of the
+                figure. Requires `distance_units`
             - 'abs_azimuth': absolute vertical spacing of waveforms defined
                 by source-receiver azimuth (deg).
             - 'abs_backazimuth': absolute vertical spacing of waveforms by
@@ -1730,6 +1732,10 @@ class RecordSection:
             ytick_major = self.kwargs.get("ytick_major", 90)
             ylabel = f"Azimuth [{DEG}]"
 
+        # Reverse the y-axis to get small values on top when sorting by
+        # distance or azimuth, which is counter to how a y-axis plotted
+        self.ax.invert_yaxis()
+
         # Set ytick label major and minor which is either dist or az
         self.ax.yaxis.set_major_locator(MultipleLocator(ytick_major))
         self.ax.yaxis.set_minor_locator(MultipleLocator(ytick_minor))
@@ -1982,10 +1988,11 @@ def parse_args():
             - 'backazimuth': sort by source-receiver backazimuth (deg) with
                 constant vertical spacing. Requires `azimuth_start_deg`
             - 'distance': sort by source-receiver distance (km) with constant
-                vertical spacing. Requires `azimuth_start_deg` AND
-                `distance_units`
+                vertical spacing. Smallest distances at top of figure. 
+                Requires `distance_units`
             - 'abs_distance': absolute vertical spacing of waveforms defined by
-                source-receiver distance (km). Requires `distance_units`
+                source-receiver distance (km). Smallest distances at top of 
+                figure. Requires `distance_units`
             - 'abs_azimuth': absolute vertical spacing of waveforms defined
                 by source-receiver azimuth (deg). Requires
                 `azimuth_start_deg`

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -348,8 +348,12 @@ class RecordSection:
             - 'y_axis': Replace tick labels on the y-axis (left side of figure),
                 This won't work if using absolute sorting and will be over-
                 written by 'default'
-            - 'y_axis_abs': Waveform labels overlapping with y-axis labels
+            - 'y_axis_abs': For absolute y-axis only. waveform labels plotted
+               on the left side outside border, with y-axis labels overlapping
                (showing distance or azimuth)
+            - 'y_axis_abs_right': For absolute y-axis only. waveform labels
+               plotted on the right side outside border, with y-axis labels
+               on the left side of the figure (showing distance or azimuth)
             - 'y_axis_right': Replace tick labels on the right side of the
                 y-axis. This option won't work with absolute sorting
             - 'x_min': Place labels on top of the waveforms at the global min
@@ -664,7 +668,8 @@ class RecordSection:
                 err.xlim_s = f"start time must be less than stop time"
 
         acceptable_y_label_loc = ["default", "y_axis", "y_axis_right", "x_min",
-                                  "x_max", "y_axis_abs", None]
+                                  "x_max", "y_axis_abs", "y_axis_abs_right",
+                                  None]
         if self.y_label_loc not in acceptable_y_label_loc:
             err.y_label_loc = f"must be in {acceptable_y_label_loc}"
         if "abs" in self.sort_by and "y_axis" in self.sort_by:
@@ -1667,7 +1672,7 @@ class RecordSection:
             if self.y_label_loc is not None:
                 # By default, place absolute sorted labels on y-axis
                 if self.y_label_loc == "default":
-                    loc = "y_axis_abs"
+                    loc = "y_axis_abs_right"
                 else:
                     loc = self.y_label_loc
                 self._set_y_axis_text_labels(start=start, stop=stop, loc=loc)
@@ -1852,6 +1857,13 @@ class RecordSection:
                 func = min
                 x_val = func(self.stats.xmin)
                 plt.text(0, .99, y_fmt, ha=ha, va=va,
+                         transform=self.ax.transAxes, fontsize=fontsize)
+            elif loc == "y_axis_abs_right":
+                ha = "left"
+                va = "center"
+                func = max
+                x_val = func(self.stats.xmax)
+                plt.text(1., .99, y_fmt, ha=ha, va=va,
                          transform=self.ax.transAxes, fontsize=fontsize)
 
             if self.xlim_s is not None:

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1638,9 +1638,9 @@ class RecordSection:
         if start is not None and stop is not None:
             min_az = self.azimuths[self.sorted_idx[start:stop]].min()
             max_az = self.azimuths[self.sorted_idx[start:stop]].max()
-            # Find the closest azimiuth bins
+            # Find the closest azimuth bins
             idx_start = np.argmin(np.abs(azimuth_bins - min_az))
-            idx_end = np.argmax(np.abs(azimuth_bins - max_az))
+            idx_end = np.argmin(np.abs(azimuth_bins - max_az))
             azimuth_bins = azimuth_bins[idx_start:idx_end]
 
         # In an absolute plot, the y values are simply the azimuth bins


### PR DESCRIPTION
Address #75 fixing sorting order and multi-page record sections. This PR is submitted prematurely in the interest of saving some time, and does not address all topics

Changelog:

1. reverse sort order for `abs_distance` and `abs_distance_r`. `abs_distance` now has smallest distance at the top of figure
2. reverse sort order for `abs_azimuth` and `abs_azimuth_r`. `abs_azimuth` now has smallest azimuth at the top of figure
3. bugfix: y-label locations for absolute sorting not showing properly, they now show outside the right-side border of the record section
4. fix multi-page sort order for `abs_distance` and `abs_distance_r` record sections. the order of pages outputted by multi-page sorting starts at the top of the equivalent single-page record section
6. fix multi-page sort order for `abs_azimuth` and `abs_azimuth_r` record sections. the order of pages outputted by multi-page sorting starts at the top of the equivalent single-page record section

Still to address in #75 
- maintain consistent trace spacing for multi-page `abs_*` sorting 
- nonzero azimuth starting point for multi-page record sections does not behave as expected, value do not wrap from 0 to 360 so there is a large white space left)
- ensure unique azimuthal lines for multi-page `abs_azimuth` and `abs_azimuth_r`. 
