### PR TITLE
improve source receiver map plotting

### DIFF
--- a/pysep/utils/plot.py
+++ b/pysep/utils/plot.py
@@ -171,12 +171,11 @@ def plot_source_receiver_map(inv, event, save="./station_map.png",
     # Temp change the size of all text objects to get text labels small
     # and make the event size a bit smaller
     with plt.rc_context({"font.size": 6, "lines.markersize": 4}):
-        Catalog(events=[event]).plot(method="cartopy", label=None, show=False)
-
-        inv.plot(projection=projection, resolution="i", label=True, show=False,
-                 size=12, color="g", method="cartopy", fig=plt.gcf())
-        # !!! fig=plt.gca() kwarg is a workaround for bug in
-        # !!! ObsPy==1.3.0 (obspy.imaging.maps._plot_cartopy_into_axes)
+        Catalog(events=[event]).plot(projection=projection, resolution="i", 
+                                     method="cartopy", label=None, show=False,
+                                     title="")
+        inv.plot(label=True, show=False, size=12, color="g", method="cartopy", 
+                 fig=plt.gcf())
 
     # Hijack the ObsPy plot and make some adjustments to make it look nicer
     ax = plt.gca()


### PR DESCRIPTION
Related to #82 

Previous source receiver map was very simple and not well adapted to global scales. It also did not center plots on the hypocenter of the event causing issues when the event was not located within the domain.

Changelog:
- Catalog is plotted first, which centers figure around event hypocenter (except for global figures)
- Logic check now selects between 'local' (<5000km), 'ortho' (<10000km) and 'global' projections based on the maximum source-receiver distance
- Allow subsetting stations in the inventory based on trace ids
    ```python
    subset = [tr.get_id() for tr in st][:100]
    plot_source_receiver_map(inv=inv, event=event, subset=subset)
    ```

Two examples to show different plotting scales:
![global](https://user-images.githubusercontent.com/23055374/222238038-b86f509e-59a5-45e8-a56b-e84d02815261.png)
![local](https://user-images.githubusercontent.com/23055374/222238051-8dbde385-1fd1-4ad9-bf4b-4868acc5e300.png)
