### PR TITLE
improve TauP theoretical arrival usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Python Seismogram Extraction and Processing
 [![PyPI Version](https://img.shields.io/pypi/v/pysep-adjtomo.svg)](https://pypi.python.org/pypi/pysep-adjtomo)
 [![SCOPED](https://img.shields.io/endpoint?url=https://runkit.io/wangyinz/scoped/branches/master/pysep)](https://github.com/SeisSCOPED/container/pkgs/container/pysep)
 
-`PySEP` uses ObsPy routines to request and standardize seismic data and metadata, outputting formatted SAC files that are ready for moment tensor and waveform inversion techniques. The package also contains `RecSec` a **rec**ord **sec**tion plotter for rapid visualization of
-waveform data.
+`PySEP` uses ObsPy routines to request and standardize seismic data and metadata, returning uniform, consistent, and minimally processed waveforms for use in moment tensor and waveform inversions. 
+
+The package also contains core classes `RecSec` a **rec**ord **sec**tion plotter for rapid visualization of
+waveform data, and `Declust`, for earthquake catalog declustering and geographical source-receiver weighting for waveform inversions.
 
 - Documentation can found on GitHub pages: https://adjtomo.github.io/pysep/
 - Found a bug, requesting a new feature, or wanting to know how to use`PySEP`? [Feel free to open a GitHub issue](https://github.com/adjtomo/pysep/issues).

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -60,7 +60,7 @@ class Pysep:
                  mindistance=0, maxdistance=20E3, minazimuth=0, maxazimuth=360,
                  minlatitude=None, minlongitude=None, maxlatitude=None,
                  maxlongitude=None, resample_freq=None, scale_factor=1,
-                 phase_list=None, seconds_before_event=20,
+                 phase_list=("ttall",), seconds_before_event=20,
                  seconds_after_event=20, seconds_before_ref=100,
                  seconds_after_ref=300, taup_model="ak135", output_unit="VEL",
                  user=None, password=None, client_debug=False,
@@ -282,9 +282,11 @@ class Pysep:
 
         :type phase_list: list of str
         :param phase_list: phase names to get ray information from TauP with.
-            Defaults to direct arrivals 'P' and 'S'. Must match Phases expected
-            by TauP (see ObsPy TauP documentation for acceptable phases). Phase
-            information will be added to SAC headers.
+            Defaults to 'ttall', which is ObsPy's default for getting all phase
+            arrivals. Must match Phases expected by TauP (see ObsPy TauP
+            documentation for acceptable phases). Earliest P and S phase
+            arrivals will be added to SAC headers, the remainder will be
+            discarded.
         :type taup_model: str
         :param taup_model: name of TauP model to use to calculate phase arrivals
             See also `phase_list` which defines phases to grab arrival data

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -99,7 +99,7 @@ from obspy import read, Stream
 from obspy.geodetics import (kilometers2degrees, gps2dist_azimuth)
 
 from pysep import logger
-from pysep.utils.cap_sac import origin_time_from_sac_header
+from pysep.utils.cap_sac import origin_time_from_sac_header, SACDICT
 from pysep.utils.io import read_sem, read_sem_cartesian
 from pysep.utils.curtail import subset_streams
 from pysep.utils.plot import plot_geometric_spreading, set_plot_aesthetic
@@ -233,7 +233,7 @@ class RecordSection:
                 distnace, d. 'k' is the `geometric_spreading_k_val` and 'f' is
                 the `geometric_spreading_factor`.
                 'k' is calculated automatically if not given.
-        :type time_shift_s: float OR list of float
+        :type time_shift_s: float OR list of float OR str
         :param time_shift_s: apply static time shift to waveforms, two options:
 
             1. float (e.g., -10.2), will shift ALL waveforms by
@@ -241,6 +241,14 @@ class RecordSection:
             2. list (e.g., [5., -2., ... 11.2]), will apply individual time
                 shifts to EACH trace in the stream. The length of this list MUST
                 match the number of traces in your input stream.
+            3. str: apply time shift based on a theoretical TauP phase arrival
+                if available in the SAC header. These should have been appended
+                by PySEP during data download. If no value is available in the
+                SAC header, defaults to 0. This may have unintended consequences
+                so you should manually check that all values are okay.
+                Available options are:
+                - 'a': shift based on earliest phase arrival
+                - '
         :type zero_pad_s: list
         :param zero_pad_s: zero pad data in units of seconsd. applied after
             tapering and before filtering. Input as a tuple of floats,

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -984,7 +984,7 @@ class RecordSection:
             elif isinstance(self.time_shift_s, str):
                 sac_key = SACDICT[self.time_shift_s]
                 logger.info(f"apply time shift by {self.time_shift_s}")
-                time_shift_arr = [tr.stats.sac[sac_key] for tr in self.st]
+                time_shift_arr = [-1 * tr.stats.sac[sac_key] for tr in self.st]
         time_shift_arr = np.array(time_shift_arr)
 
         # Further change the time shift if we have move out input

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -974,13 +974,16 @@ class RecordSection:
         if self.time_shift_s is not None:
             # User inputs a static time shift
             if isinstance(self.time_shift_s, float):
+                logger.info(f"apply constant time shift {self.time_shift_s}s")
                 time_shift_arr += self.time_shift_s
             # User input an array which should have already been checked for len
             elif isinstance(self.time_shift_s, list):
+                logger.info(f"apply user-defined array time shift values")
                 time_shift_arr = self.time_shift_s
             # Allow shifting by a given phase arrival in the SAC header
             elif isinstance(self.time_shift_s, str):
                 sac_key = SACDICT[self.time_shift_s]
+                logger.info(f"apply time shift by {self.time_shift_s}")
                 time_shift_arr = [tr.stats.sac[sac_key] for tr in self.st]
         time_shift_arr = np.array(time_shift_arr)
 

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_format_sac_headers_w_taup_traveltimes(test_st, test_inv, test_event):
     """
     st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
     st = format_sac_header_w_taup_traveltimes(st=st, model="ak135")
-    assert(pytest.approx(st[0].stats.sac["user4"], .01) == 57.66)
+    assert(pytest.approx(st[0].stats.sac["a"], .01) == 224.535)
 
 
 def test_sac_header_correct_origin_time(tmpdir, test_st, test_inv, test_event):

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -16,6 +16,7 @@ from pysep.utils.fetch import get_taup_arrivals
 
 # SAC HEADER CONSTANTS DEFINING NON-INTUITIVE QUANTITIES
 SACDICT = {
+    "earliest_arrival": "a",
     "p_arrival_time": "t5",
     "p_incident_angle": "user1",
     "p_takeoff_angle": "user3",
@@ -31,7 +32,6 @@ def write_cap_weights_files(st, path_out="./", order_by="dist"):
     assuming that SAC headers are already present.
 
     TODO re-add Ptime setting with event.picks
-
 
     Replaces `write_cap_weights`
 
@@ -286,8 +286,8 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
 
         phase = arrivals[idx]  # Earliest Arrival object
-        tr.stats.sac["a"] = phase.time  # relative time sec: float
-        tr.stats.sac["ka"] = f"{phase.name}"  # name: str
+        tr.stats.sac[SACDICT["earliest_arrival"]] = phase.time  # 'a'
+        tr.stats.sac[f"k{SACDICT['earliest_arrival']}"] = f"{phase.name}"  # ka
 
         # Find earliest arriving P phase (must start with letter 'P')
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -233,7 +233,8 @@ def _append_sac_headers_trace(tr, event, inv):
     return tr
 
 
-def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
+def format_sac_header_w_taup_traveltimes(st, model="ak135",
+                                         phase_list=("ttall",)):
     """
     Add TauP travel times to the SAC headers using information in the SAC header
     Also get some information from TauP regarding incident angle, takeoff angle
@@ -256,8 +257,9 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
         defaults to 'ak135'
     :type phase_list: list of str
     :param phase_list: phase names to get ray information from TauP with.
-        Defaults to direct arrivals 'P' and 'S'. Must match Phases expected
-        by TauP (see ObsPy TauP documentation for acceptable phases).
+        Defaults to 'ttall', which is ObsPy's default for getting all phase
+        arrivals. Must match Phases expected by TauP (see ObsPy TauP
+        documentation for acceptable phases).
     """
     st_out = st.copy()
 
@@ -276,7 +278,6 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
                            f"append arrival time SAC headers")
             continue
         # Find earliest arriving P-wave (P or p)
-        import pdb;pdb.set_trace()
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
                      a.name.upper() == "P"]
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -302,7 +302,7 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         tr.stats.sac[SACDICT["p_incident_angle"]] = p.incident_angle
         tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"p_IncAng"
         tr.stats.sac[SACDICT["p_takeoff_angle"]] = arrivals[idx].takeoff_angle
-        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"p_TkfAng"
+        tr.stats.sac[f"k{SACDICT['p_takeoff_angle']}"] = f"p_TkfAng"
 
         # Find earliest arriving S phase (must start with letter 'S')
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
@@ -316,7 +316,7 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         tr.stats.sac[SACDICT["s_incident_angle"]] = s.incident_angle
         tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"s_IncAng"
         tr.stats.sac[SACDICT["s_takeoff_angle"]] = s.takeoff_angle
-        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"s_TkfAng"
+        tr.stats.sac[f"k{SACDICT['s_takeoff_angle']}"] = f"s_TkfAng"
 
     return st_out
 

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -261,10 +261,6 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
     """
     st_out = st.copy()
 
-    # Call TauP with a specific model to retrieve travel times etc.
-    if not phase_list:
-        phase_list = ["p", "P", "s", "S"]
-
     phase_dict = get_taup_arrivals_with_sac_headers(st=st, model=model,
                                                     phase_list=phase_list)
     # Arrivals may return multiple entires for each phase, pick earliest
@@ -280,6 +276,7 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135", phase_list=None):
                            f"append arrival time SAC headers")
             continue
         # Find earliest arriving P-wave (P or p)
+        import pdb;pdb.set_trace()
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
                      a.name.upper() == "P"]
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -281,7 +281,7 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
                            f"append arrival time SAC headers")
             continue
 
-        # Find earliest arriving phase (likely a P phase but keep it general)
+        # Find earliest arriving phase (likely same as P phase but maybe not)
         idx_times = [(i, a.time) for i, a in enumerate(arrivals)]
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
 
@@ -289,7 +289,7 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         tr.stats.sac["a"] = phase.time  # relative time sec: float
         tr.stats.sac["ka"] = f"{phase.name}"  # name: str
 
-        # Find earliest arriving P phase
+        # Find earliest arriving P phase (must start with letter 'P')
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
                      a.name.upper().startswith("P")]
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
@@ -300,11 +300,11 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
 
         # P phase incident angle (ia) and takeoff angle (ta)
         tr.stats.sac[SACDICT["p_incident_angle"]] = p.incident_angle
-        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ia"
+        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"p_IncAng"
         tr.stats.sac[SACDICT["p_takeoff_angle"]] = arrivals[idx].takeoff_angle
-        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ta"
+        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"p_TkfAng"
 
-        # Find earliest arriving S phase
+        # Find earliest arriving S phase (must start with letter 'S')
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
                      a.name.upper().startswith("S")]
         idx, _ = min(idx_times, key=lambda x: x[1])
@@ -314,9 +314,9 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         tr.stats.sac[f"k{SACDICT['s_arrival_time']}"] = f"{s.name}"
 
         tr.stats.sac[SACDICT["s_incident_angle"]] = s.incident_angle
-        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"{s.name}_ia"
+        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"s_IncAng"
         tr.stats.sac[SACDICT["s_takeoff_angle"]] = s.takeoff_angle
-        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"{s.name}_ta"
+        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"s_TkfAng"
 
     return st_out
 

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -12,7 +12,7 @@ from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from pysep import logger
 from pysep.utils.fmt import format_event_tag_legacy
-from pysep.utils.fetch import get_taup_arrivals_with_sac_headers
+from pysep.utils.fetch import get_taup_arrivals
 
 # SAC HEADER CONSTANTS DEFINING NON-INTUITIVE QUANTITIES
 SACDICT = {
@@ -262,9 +262,8 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         documentation for acceptable phases).
     """
     st_out = st.copy()
+    phase_dict = get_taup_arrivals(st=st, model=model, phase_list=phase_list)
 
-    phase_dict = get_taup_arrivals_with_sac_headers(st=st, model=model,
-                                                    phase_list=phase_list)
     # Arrivals may return multiple entires for each phase, pick earliest
     for tr in st_out[:]:
         # Missing SAC header values may cause certain or all stations to not 

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -16,7 +16,7 @@ from pysep.utils.fetch import get_taup_arrivals
 
 # SAC HEADER CONSTANTS DEFINING NON-INTUITIVE QUANTITIES
 SACDICT = {
-    "earliest_arrival": "a",
+    "first_arrival_time": "a",
     "p_arrival_time": "t5",
     "p_incident_angle": "user1",
     "p_takeoff_angle": "user3",
@@ -286,8 +286,8 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
 
         phase = arrivals[idx]  # Earliest Arrival object
-        tr.stats.sac[SACDICT["earliest_arrival"]] = phase.time  # 'a'
-        tr.stats.sac[f"k{SACDICT['earliest_arrival']}"] = f"{phase.name}"  # ka
+        tr.stats.sac[SACDICT["first_arrival_time"]] = phase.time  # 'a'
+        tr.stats.sac[f"k{SACDICT['first_arrival_time']}"] = f"{phase.name}" #ka
 
         # Find earliest arriving P phase (must start with letter 'P')
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -266,20 +266,26 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
 
     # Arrivals may return multiple entires for each phase, pick earliest
     for tr in st_out[:]:
+        net_sta = ".".join(tr.get_id().split(".")[:2])  # NN.SSS
+
         # Missing SAC header values may cause certain or all stations to not 
         # be present in the `phase_dict`
-        if tr.get_id() not in phase_dict:
-            continue
-        arrivals = phase_dict[tr.get_id()]
-        # If the TauP arrival calculation fails, `arrivals` will be empty
-        if not arrivals:
-            logger.warning(f"{tr.get_id()} has no TauP phase arrivals, cannot "
+        if net_sta not in phase_dict:
+            logger.warning(f"{tr.get_id()} not present in TauP arrivals, cant "
                            f"append arrival time SAC headers")
             continue
+        arrivals = phase_dict[net_sta]
+        # If the TauP arrival calculation fails, `arrivals` will be empty
+        if not arrivals:
+            logger.warning(f"{tr.get_id()} has no TauP phase arrivals, cant "
+                           f"append arrival time SAC headers")
+            continue
+
         # Find earliest arriving P-wave (P or p)
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
-                     a.name.upper() == "P"]
+                     a.name.upper().startswith("P")]
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
+
         p = arrivals[idx]  # Earliest P-wave Arrival object
 
         tr.stats.sac["a"] = p.time  # relative time sec: float
@@ -296,7 +302,7 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
 
         # Find earliest arriving S-wave (S or s)
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
-                     a.name.upper() == "S"]
+                     a.name.upper().startswith("S")]
         idx, _ = min(idx_times, key=lambda x: x[1])
         s = arrivals[idx]  # Earliest S-wave Arrival object
 

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -281,26 +281,30 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
                            f"append arrival time SAC headers")
             continue
 
-        # Find earliest arriving P-wave (P or p)
+        # Find earliest arriving phase (likely a P phase but keep it general)
+        idx_times = [(i, a.time) for i, a in enumerate(arrivals)]
+        idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
+
+        phase = arrivals[idx]  # Earliest Arrival object
+        tr.stats.sac["a"] = phase.time  # relative time sec: float
+        tr.stats.sac["ka"] = f"{phase.name}"  # name: str
+
+        # Find earliest arriving P phase
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
                      a.name.upper().startswith("P")]
         idx, _ = min(idx_times, key=lambda x: x[1])  # find index of min time
 
         p = arrivals[idx]  # Earliest P-wave Arrival object
-
-        tr.stats.sac["a"] = p.time  # relative time sec: float
-        tr.stats.sac["ka"] = f"{p.name}"  # name: str
-
         tr.stats.sac[SACDICT["p_arrival_time"]] = p.time
         tr.stats.sac[f"k{SACDICT['p_arrival_time']}"] = f"{p.name}"
 
-        # P-wave incident angle (ia) and takeoff angle (ta)
+        # P phase incident angle (ia) and takeoff angle (ta)
         tr.stats.sac[SACDICT["p_incident_angle"]] = p.incident_angle
         tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ia"
         tr.stats.sac[SACDICT["p_takeoff_angle"]] = arrivals[idx].takeoff_angle
         tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ta"
 
-        # Find earliest arriving S-wave (S or s)
+        # Find earliest arriving S phase
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
                      a.name.upper().startswith("S")]
         idx, _ = min(idx_times, key=lambda x: x[1])

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -289,16 +289,16 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         p = arrivals[idx]  # Earliest P-wave Arrival object
 
         tr.stats.sac["a"] = p.time  # relative time sec: float
-        tr.stats.sac["ka"] = f"{p.name}_{model}"  # name: str
+        tr.stats.sac["ka"] = f"{p.name}"  # name: str
 
         tr.stats.sac[SACDICT["p_arrival_time"]] = p.time
-        tr.stats.sac[f"k{SACDICT['p_arrival_time']}"] = f"{p.name}_{model}"
+        tr.stats.sac[f"k{SACDICT['p_arrival_time']}"] = f"{p.name}"
 
         # P-wave incident angle (ia) and takeoff angle (ta)
         tr.stats.sac[SACDICT["p_incident_angle"]] = p.incident_angle
-        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ia_{model}"
+        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ia"
         tr.stats.sac[SACDICT["p_takeoff_angle"]] = arrivals[idx].takeoff_angle
-        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ta_{model}"
+        tr.stats.sac[f"k{SACDICT['p_incident_angle']}"] = f"{p.name}_ta"
 
         # Find earliest arriving S-wave (S or s)
         idx_times = [(i, a.time) for i, a in enumerate(arrivals) if
@@ -307,12 +307,12 @@ def format_sac_header_w_taup_traveltimes(st, model="ak135",
         s = arrivals[idx]  # Earliest S-wave Arrival object
 
         tr.stats.sac[SACDICT["s_arrival_time"]] = s.time
-        tr.stats.sac[f"k{SACDICT['s_arrival_time']}"] = f"{s.name}_{model}"
+        tr.stats.sac[f"k{SACDICT['s_arrival_time']}"] = f"{s.name}"
 
         tr.stats.sac[SACDICT["s_incident_angle"]] = s.incident_angle
-        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"{s.name}_ia_{model}"
+        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"{s.name}_ia"
         tr.stats.sac[SACDICT["s_takeoff_angle"]] = s.takeoff_angle
-        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"{s.name}_ta_{model}"
+        tr.stats.sac[f"k{SACDICT['s_incident_angle']}"] = f"{s.name}_ta"
 
     return st_out
 

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -11,10 +11,17 @@ from obspy.geodetics import kilometer2degrees, gps2dist_azimuth
 from pysep import logger
 
 
-def get_taup_arrivals_with_sac_headers(st, phase_list=("ttall",), model="ak135"):
+
+def get_taup_arrivals(st=None, event=None, inv=None, phase_list=("ttall",),
+                      model="ak135", network=None, station=None):
     """
-    Retrieve phase arrival times using TauP/TauPy based on a SAC header
-    appended to a trace
+    Retrieve phase arrival times using TauP/TauPy based on event and station
+    locations, either using SAC headers or using event and inventory metadata.
+
+    .. note::
+
+        Requires EITHER `st` with appropriate SAC headers OR
+        `event` and `inv` defining event and station locations.
 
     Available model names can be found here:
         https://docs.obspy.org/packages/obspy.taup.html
@@ -24,62 +31,6 @@ def get_taup_arrivals_with_sac_headers(st, phase_list=("ttall",), model="ak135")
     :type st: obspy.core.stream.Stream
     :param st: Stream with appended SAC headers which will be used to gather
         TaupP arrivals from a given `model`
-    :type phase_list: list of str
-    :param phase_list: phases to search TauP for. Defaults to 'ttall', which is
-        ObsPy's default for getting all phase arrivals
-    :type model: str
-    :param model: Model to query TauP with. Looks at ObsPy and PySEP models
-    :rtype: dict
-    :return: a dictionary where keys are trace ID's (from trace.get_id()), and
-        values are TauP Arrivals() instances which contain information about
-        phase arrivals
-    """
-    phase_dict = {}
-    taup_model = _get_or_build_taup_model(model)
-
-    taup_func = taup_model.get_travel_times
-    # taup_func = taup_model.get_ray_paths  # use if you want to plot ray paths
-
-    logger.debug(f"fetching arrivals, phases {phase_list} and model '{model}'")
-    for tr in st:
-        sac_header = tr.stats.sac
-        if "evdp" not in sac_header or "gcarc" not in sac_header:
-            logger.debug(f"skip {tr.get_id()} phase arr., no 'evdp' or 'gcarc")
-            continue
-        depth_km = sac_header["evdp"]  # units: km
-        dist_deg = sac_header["gcarc"]
-        while True:
-            try:
-                arrivals = taup_func(source_depth_in_km=depth_km,
-                                     distance_in_degree=dist_deg,
-                                     phase_list=phase_list)
-                if not arrivals:
-                    logger.debug(f"no TauP arrivals for model {model} and "
-                                 f"phases: {phase_list}")
-                phase_dict[tr.get_id()] = arrivals
-                break
-            # This will through a ValueError for invalid phase names
-            except ValueError as e:
-                # Assuming that the error message lists the phase name last
-                logger.warning(f"{e}")
-                del_phase = str(e).split(" ")[-1]
-                phase_list.remove(del_phase)
-                pass
-
-    return phase_dict
-
-
-def get_taup_arrivals(event, inv, phase_list=("ttall",), model="ak135",
-                      network=None, station=None):
-    """
-    Retrieve phase arrival times using TauP/TauPy based on event and stations.
-    By default only retrieve for first arrivals.
-
-    Available model names can be found here:
-        https://docs.obspy.org/packages/obspy.taup.html
-    OR internally at:
-        pysep/pysep/data/taup_models
-
     :type event: obspy.core.event.Event
     :param event: Event object to get location from
     :type inv: obspy.core.inventory.Inventory
@@ -98,30 +49,47 @@ def get_taup_arrivals(event, inv, phase_list=("ttall",), model="ak135",
         values are TauP Arrivals() instances which contain information about
         phase arrivals
     """
+    if st is not None:
+        logger.debug(f"using SAC headers to fetch phase arrivals '{phase_list}'"
+                     f"from model '{model}'")
+    else:
+        assert(event is not None and inv is not None), (
+            f"`get_taup_arrivals` requires `st` w/ SAC headers OR `event` and " 
+            f"`inv` defining event and stations."
+        )
+        logger.debug(f"using event and station metadata to fetch phase "
+                     f"arrivals '{phase_list}' from model '{model}'")
+
     phase_dict = {}
     taup_model = _get_or_build_taup_model(model)
-
     taup_func = taup_model.get_travel_times
-    # taup_func = taup_model.get_ray_paths  # use if you want to plot ray paths
 
-    logger.debug(f"fetching arrivals, phases {phase_list} and model '{model}'")
-    for net in inv.select(network=network, station=station):
-        for sta in net:
-            code = f"{net.code}.{sta.code}"
-            dist_m, az, baz = gps2dist_azimuth(
-                lat1=event.preferred_origin().latitude,
-                lon1=event.preferred_origin().longitude,
-                lat2=sta.latitude, lon2=sta.longitude
-            )
-            dist_km = dist_m / 1E3
-            dist_deg = kilometer2degrees(dist_km, radius=6371)
-            depth_km = event.preferred_origin().depth / 1E3  # units: m -> km
+    # OPTION 1: Retrieve event and station metadata from SAC headers
+    if st is not None:
+        for tr in st:
+            # Allow selecting for specific networks and stations
+            net, sta, *_ = tr.get_id().split(".")
+            if network and net != network:
+                continue
+            if station and sta != station:
+                continue
+
+            sac_header = tr.stats.sac
+            if "evdp" not in sac_header or "gcarc" not in sac_header:
+                logger.debug(f"skip {tr.get_id()} phase arr., no 'evdp' or "
+                             f"'gcarc")
+                continue
+            depth_km = sac_header["evdp"]  # units: km
+            dist_deg = sac_header["gcarc"]
             while True:
                 try:
                     arrivals = taup_func(source_depth_in_km=depth_km,
                                          distance_in_degree=dist_deg,
                                          phase_list=phase_list)
-                    phase_dict[code] = arrivals
+                    if not arrivals:
+                        logger.debug(f"no TauP arrivals for model {model} and "
+                                     f"phases: {phase_list}")
+                    phase_dict[tr.get_id()] = arrivals
                     break
                 # This will through a ValueError for invalid phase names
                 except ValueError as e:
@@ -130,6 +98,33 @@ def get_taup_arrivals(event, inv, phase_list=("ttall",), model="ak135",
                     del_phase = str(e).split(" ")[-1]
                     phase_list.remove(del_phase)
                     pass
+    # OPTION 2: Retrieve event and station metadata from metadata objects
+    else:
+        for net in inv.select(network=network, station=station):
+            for sta in net:
+                code = f"{net.code}.{sta.code}"
+                dist_m, az, baz = gps2dist_azimuth(
+                    lat1=event.preferred_origin().latitude,
+                    lon1=event.preferred_origin().longitude,
+                    lat2=sta.latitude, lon2=sta.longitude
+                )
+                dist_km = dist_m / 1E3
+                dist_deg = kilometer2degrees(dist_km, radius=6371)
+                depth_km = event.preferred_origin().depth / 1E3  # units: m -> km
+                while True:
+                    try:
+                        arrivals = taup_func(source_depth_in_km=depth_km,
+                                             distance_in_degree=dist_deg,
+                                             phase_list=phase_list)
+                        phase_dict[code] = arrivals
+                        break
+                    # This will through a ValueError for invalid phase names
+                    except ValueError as e:
+                        # Assuming that the error message lists the phase name last
+                        logger.warning(f"{e}")
+                        del_phase = str(e).split(" ")[-1]
+                        phase_list.remove(del_phase)
+                        pass
 
     return phase_dict
 

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -45,9 +45,9 @@ def get_taup_arrivals(st=None, event=None, inv=None, phase_list=("ttall",),
     :type station: str
     :param station: query only a specific station
     :rtype: dict
-    :return: a dictionary where keys are trace ID's (from trace.get_id()), and
-        values are TauP Arrivals() instances which contain information about
-        phase arrivals
+    :return: a dictionary where keys are trace ID consisting of network and
+        station (NN.SSS), and values are TauP Arrivals() instances which
+        contain information about phase arrivals
     """
     if st is not None:
         logger.debug(f"using SAC headers to fetch phase arrivals '{phase_list}'"
@@ -69,6 +69,7 @@ def get_taup_arrivals(st=None, event=None, inv=None, phase_list=("ttall",),
         for tr in st:
             # Allow selecting for specific networks and stations
             net, sta, *_ = tr.get_id().split(".")
+            trace_id = f"{net}.{sta}"
             if network and net != network:
                 continue
             if station and sta != station:
@@ -89,12 +90,13 @@ def get_taup_arrivals(st=None, event=None, inv=None, phase_list=("ttall",),
                     if not arrivals:
                         logger.debug(f"no TauP arrivals for model {model} and "
                                      f"phases: {phase_list}")
-                    phase_dict[tr.get_id()] = arrivals
+                    phase_dict[trace_id] = arrivals
                     break
                 # This will through a ValueError for invalid phase names
                 except ValueError as e:
                     # Assuming that the error message lists the phase name last
-                    logger.warning(f"{e}")
+                    logger.warning(f"'{e}' invalid phase name, removing from "
+                                   f"phase list")
                     del_phase = str(e).split(" ")[-1]
                     phase_list.remove(del_phase)
                     pass
@@ -120,8 +122,9 @@ def get_taup_arrivals(st=None, event=None, inv=None, phase_list=("ttall",),
                         break
                     # This will through a ValueError for invalid phase names
                     except ValueError as e:
-                        # Assuming that the error message lists the phase name last
-                        logger.warning(f"{e}")
+                        # Assuming that the error message lists phase name last
+                        logger.warning(f"'{e}' invalid phase name, removing "
+                                       f"from phase list")
                         del_phase = str(e).split(" ")[-1]
                         phase_list.remove(del_phase)
                         pass

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -34,9 +34,6 @@ def get_taup_arrivals_with_sac_headers(st, phase_list=None, model="ak135",):
         phase arrivals
     """
     phase_dict = {}
-    if phase_list is None:
-        phase_list = ["P", "S"]
-
     taup_model = _get_or_build_taup_model(model)
 
     taup_func = taup_model.get_travel_times
@@ -100,9 +97,6 @@ def get_taup_arrivals(event, inv, phase_list=None, model="ak135", network=None,
         phase arrivals
     """
     phase_dict = {}
-    if phase_list is None:
-        phase_list = ["P", "S"]
-
     taup_model = _get_or_build_taup_model(model)
 
     taup_func = taup_model.get_travel_times

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -11,7 +11,7 @@ from obspy.geodetics import kilometer2degrees, gps2dist_azimuth
 from pysep import logger
 
 
-def get_taup_arrivals_with_sac_headers(st, phase_list=None, model="ak135",):
+def get_taup_arrivals_with_sac_headers(st, phase_list=("ttall",), model="ak135"):
     """
     Retrieve phase arrival times using TauP/TauPy based on a SAC header
     appended to a trace
@@ -25,7 +25,8 @@ def get_taup_arrivals_with_sac_headers(st, phase_list=None, model="ak135",):
     :param st: Stream with appended SAC headers which will be used to gather
         TaupP arrivals from a given `model`
     :type phase_list: list of str
-    :param phase_list: phases to search TauP for. Defaults to 'P' and 'S'
+    :param phase_list: phases to search TauP for. Defaults to 'ttall', which is
+        ObsPy's default for getting all phase arrivals
     :type model: str
     :param model: Model to query TauP with. Looks at ObsPy and PySEP models
     :rtype: dict
@@ -68,8 +69,8 @@ def get_taup_arrivals_with_sac_headers(st, phase_list=None, model="ak135",):
     return phase_dict
 
 
-def get_taup_arrivals(event, inv, phase_list=None, model="ak135", network=None,
-                      station=None):
+def get_taup_arrivals(event, inv, phase_list=("ttall",), model="ak135",
+                      network=None, station=None):
     """
     Retrieve phase arrival times using TauP/TauPy based on event and stations.
     By default only retrieve for first arrivals.
@@ -84,7 +85,8 @@ def get_taup_arrivals(event, inv, phase_list=None, model="ak135", network=None,
     :type inv: obspy.core.inventory.Inventory
     :param inv: inventory object to get locations from
     :type phase_list: list of str
-    :param phase_list: phases to search TauP for. Defaults to 'P' and 'S'
+    :param phase_list: phases to search TauP for.  Defaults to 'ttall', which is
+        ObsPy's default for getting all phase arrivals
     :type model: str
     :param model: Model to query TauP with. Looks at ObsPy and PySEP models
     :type network: str


### PR DESCRIPTION
Related to #92 

PySEP can append TauP theoretical arrival times to SAC headers, but the previous implementation was too rigid and failed for large source-receiver distances (>100*) because it was only allowing in phases 'P' and 'S'.

This PR fixes this system and also introduces a RecSec feature for applying per-trace time shifts based on phase arrivals.

- Removes hardcode phase list when NoneType passed in for TauP arrival times, now defaults to collecting all phases ('ttall') unless user specifies a phase list
- Merged functions `get_taup_arrival_w_sac_headers` and `get_taup_arrivals`, the new `get_taup_arrivals` can get arrival times with either SAC headers or event and inv objects (reduces code redundancy, no API change)
- Made some adjustments to SAC header input values due to hard character limit restrictions 
    - 'a' is now the earliest phase arrival regardless if its P or S (before it was hardcoded to be the same as P)
    - p and s phase arrivals are now the earliest arrive P or S phase (e.g., pdiff, before hardcoded to 'P' or 'S' only)
    - BUG FIX: takeoff angle and incident angle labels were incorrectly attributed in the SAC headers
    - drop model name and phase name from incident and takeoff angle labels
    - adds 'first_arrival_time' to the SAC dictionary, which corresponds to SAC header value 'a'
- RecordSection parameter `time_shift_s` can now take string values corresponding to SAC header values. This will align T=0 (relative) on the theoretical arrival time for each trace. Available options are:
    - 'first_arrival_time': SAC header 'a', which corresponds to earliest arriving phase (general)
    - `p_arrival_time': earliest arrive P phase
    - `s_arrival_time': earliest arrive S phase

For the new `time_shift_s` parameter input, you can use the following:
*Command line implementation*
```bash
recsec --pysep_path SAC/ --time_shift_s p_arrival_time
```
  
*Python implementation*
```python
RecordSection(time_shift_s='p_arrival_time')
```
 