### PR TITLE
General updates and bugfixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ project = 'PySEP'
 copyright = '2023, adjTomo Dev Team'
 author = 'adjTomo Dev Team'
 release = ''
-version = '0.3.1'
+version = '0.3.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysep-adjtomo"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python Seismogram Extraction and Processing"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pysep/__init__.py
+++ b/pysep/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+__version__ = "0.3.2"
+
 logger = logging.getLogger("pysep")
 logger.setLevel("INFO")
 logger.propagate = 0

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -55,7 +55,7 @@ class Pysep:
                  networks="*", stations="*", locations="*", channels="*",
                  event_latitude=None, event_longitude=None, event_depth_km=None,
                  event_magnitude=None, remove_response=True,
-                 remove_clipped=False, remove_insufficient_length=True,
+                 remove_clipped=True, remove_insufficient_length=True,
                  remove_masked_data=True,
                  water_level=60, detrend=True, demean=True, taper_percentage=0,
                  rotate=None, pre_filt="default", fill_data_gaps=False,

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -697,6 +697,8 @@ class Pysep:
                     if val != old_val:
                         logger.debug(f"{key}: {old_val} -> {val}")
                         setattr(self, key, val)
+                else:
+                    self.kwargs[key] = val
 
         # Reset log level based on the config file
         if self.log_level is not None:
@@ -1537,17 +1539,21 @@ class Pysep:
         """
         Plot map and record section if requested
         """
+        show_map = self.kwargs.get("show_map", False)
+        show_rs = self.kwargs.get("show_rs", False)
+
         if "map" in self.plot_files or "all" in self.plot_files:
             logger.info("plotting source receiver map")
             fid = os.path.join(self.output_dir, f"station_map.png")
-            plot_source_receiver_map(self.inv, self.event, save=fid)
+            plot_source_receiver_map(self.inv, self.event, save=fid, 
+                                     show=show_map)
 
         if "record_section" in self.plot_files or "all" in self.plot_files:
             fid = os.path.join(self.output_dir, f"record_section.png")
             # Default settings to create a general record section
             rs = RecordSection(st=self.st, sort_by="distance",
-                               scale_by="normalize", overwrite=True, show=False,
-                               save=fid)
+                               scale_by="normalize", overwrite=True, 
+                               show=show_rs, save=fid)
             rs.run()
 
     def _event_tag_and_output_dir(self):

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -29,7 +29,7 @@ from obspy.clients.fdsn.mass_downloader import (RectangularDomain, Restrictions,
 from obspy.core.event import Event, Origin, Magnitude
 from obspy.geodetics import kilometer2degrees
 
-from pysep import logger
+from pysep import logger, __version__
 from pysep.utils.cap_sac import (append_sac_headers, write_cap_weights_files,
                                  format_sac_header_w_taup_traveltimes,
                                  format_sac_headers_post_rotation)
@@ -1608,6 +1608,8 @@ class Pysep:
         :param st: optional user-provided strean object which will force a
             skip over waveform searching
         """
+        logger.debug(f"running PySEP version {__version__}")
+
         # Overload default parameters with event input file and check validity
         self.load(**kwargs)
         self.check()

--- a/pysep/utils/plot.py
+++ b/pysep/utils/plot.py
@@ -201,7 +201,8 @@ def plot_source_receiver_map(inv, event, subset=None, save="./station_map.png",
     ax = plt.gca()
 
     # Get the extent all points plotted to resize the figure in local
-    # since the original bounds will be just around the event
+    # since the original bounds will be confined to a small reigon around the
+    # event
     if projection == "local":
         lats, lons = [], []
         for net in inv:
@@ -214,8 +215,8 @@ def plot_source_receiver_map(inv, event, subset=None, save="./station_map.png",
         lons = np.array(lons)
 
         # Copied verbatim from obspy.imaging.maps.plot_map(), find aspect ratio
-        # based on the points plotted. Need to re-do since we have both an
-        # event and stations
+        # based on the points plotted. Need to re-do this operation since we
+        # have both event and stations
         if min(lons) < -150 and max(lons) > 150:
             max_lons = max(np.array(lons) % 360)
             min_lons = min(np.array(lons) % 360)
@@ -237,8 +238,8 @@ def plot_source_receiver_map(inv, event, subset=None, save="./station_map.png",
         else:
             height = 2.0 * deg2m_lat
             width = 5.0 * deg2m_lon
-        # Do intelligent aspect calculation for local projection
-        # adjust to figure dimensions
+        # Do intelligent aspect calculation for local projection to adjust to
+        # figure dimensions
         w, h = plt.gcf().get_size_inches()
         aspect = w / h
 
@@ -247,12 +248,11 @@ def plot_source_receiver_map(inv, event, subset=None, save="./station_map.png",
         else:
             height = width / aspect
 
-        import pdb;pdb.set_trace()
-        # x0, y0 = proj.transform_point(lon_0, lat_0, proj.as_geodetic())
-        # map_ax.set_xlim(x0 - width / 2, x0 + width / 2)
-        # map_ax.set_ylim(y0 - height / 2, y0 + height / 2)
-        #
-        # ax.set_extent([x0, x1, y0, y1])
+        # We are ASSUMING that the event is located at the center of the figure
+        # (0, 0), which it should be since we plotted it first
+        x0, y0 = 0, 0  # modified from ObsPy function
+        ax.set_xlim(x0 - width / 2, x0 + width / 2)
+        ax.set_ylim(y0 - height / 2, y0 + height / 2)
 
     # Hijack the ObsPy plot and make some adjustments to make it look nicer
     gl = ax.gridlines(draw_labels=True, dms=True, x_inline=False,


### PR DESCRIPTION
Not a very coherent theme to these changes, just addressing a few open issues in one go:

- Change parameter default for `remove_clipped` from False -> True (https://github.com/adjtomo/pysep/issues/80#issuecomment-1455243240)
- Bugfix: PySEP `load` was not retaining keyword arguments from a YAML parameter file
- Added version number to package so Users can import version number in Python (#95)
- Display PySEP version number in the debug log messages (#95)
- Map plotting: local scale plots now auto-scale like the ObsPy version of the plot function. Previously local scale figures would have event or stations out of map bounds, or have strange scales if stations were very linear in their arrangement.