### PR TITLE
overhaul file writing system plus general updates

### DIFF
--- a/docs/pysep.rst
+++ b/docs/pysep.rst
@@ -153,128 +153,90 @@ class. See the PySEP docstring for input parameter types and definitions.
 -------------------------------------------------------------------------------
 
 
-Multiple Event Input
---------------------
-
-To use the same configuration file with multiple events, you can use an event 
-file passed to PySEP through the command line.
-
-When using this option, the event parameters inside the config file will be
-ignored, but all the other parameters will be used to gather data and metadata.
-
-Event input files should be text files where each row describes one event with 
-the following parameters as columns:
-
-.. ORIGIN_TIME LONGITUDE LATITUDE DEPTH[KM] MAGNITUDE
-
-For an example event input file called 'event_input.txt', call structure is:
-
-.. code:: bash
-
-    pysep -c pysep_config.yaml -E event_input.txt
-
-.. note::
-
-    Multiple event input is only available for command line usage of PySEP.
-    We suggest using a for loop if you would like to script multiple event
-    input using PySEP
-
-
-Legacy Filenaming Schema
-------------------------
-
-The new version of PySEP uses a file naming schema that is incompatible with
-previous versions, which may lead to problems in established workflows. 
-
-To honor the legacy naming schema of PySEP, simply use the `--legacy_naming`
-argument in the command line. This will change how the event tag is formatted,
-how the output directory is structured, and how the output SAC files are named.
-
-.. code:: bash
-
-    pysep -c pysep_config.yaml --legacy_naming
-
-Or with scripting
-
-.. code:: python
-
-    sep = Pysep(legacy_naming=True, ...)
-
-
 Output Control
 --------------
 
-By default, PySEP writes all files to the User-defined parameter `output_dir`,
+By default, PySEP writes all files to the User-defined parameter ``output_dir``,
 which defaults to the current working directory.
 
-Files are normally written into a sub-directory defined by the `event_tag` which
-is dynamically generated based on the event origin time, and its Flinn-Engdahl
-region. For example
+Files are normally written into a sub-directory defined by the ``event_tag``
+which is dynamically generated based on the event origin time, and Flinn-Engdahl
+region. For example:
 
-.. code::
+..
 
     2009-04-07T201255_SOUTHERN_ALASKA
 
-All waveform files are saved in a further sub-directory `SAC`, to avoid
+All waveform files are saved in a further sub-directory ``SAC``, to avoid
 cluttering up the output directory.
 
-.. note::
-
-    Users can use the parameters `write_files` and `plot_files` to control
-    exactly what files are produced during a PySEP (`see API documentation
-    <autoapi/pysep/pysep/index.html#pysep.pysep.Pysep>`__).
+Users can use the parameters ``write_files`` and ``plot_files`` to control
+exactly what files are produced during a PySEP (see `API documentation
+<autoapi/pysep/pysep/index.html#pysep.pysep.Pysep>`__ for details).
 
 By default, PySEP will write SAC files, StationXML, QuakeML and config files,
 and create a source-receiver map and record section.
 
 Directory Control
------------------
+`````````````````
 
 In some cases it may be useful for Users to save files directly to their
 working directory, without all the automatically generated sub-directories.
 
-To ignore the automatically generated event tag, you can use the
-`overwrite_event_tag` parameter. Via the command line:
+* To ignore the automatically generated event tag, you can set the
+  ``overwrite_event_tag`` parameter as an empty string. Via the command line:
 
-.. code:: bash
+  .. code:: bash
 
-    pysep -c pysep_config.yaml --overwrite_event_tag ''
+      pysep -c pysep_config.yaml --overwrite_event_tag ''
 
-Or via scripting:
+  or via scripting:
 
-.. code:: python
+  .. code:: python
 
-    sep = Pysep(overwrite_event_tag='')
+      sep = Pysep(overwrite_event_tag="")
 
-To save waveform files directly in the output directory, use the `sac_subdir`
-parameter, which should be input in your YAML parameter file:
+* To ignore the SAC subdirectory and save waveform files directly in the
+  output directory, use the ``sac_subdir`` parameter, which should be input in
+  your YAML parameter file:
 
-.. code:: yaml
+  .. code:: yaml
 
-    sac_subdir: ''
+      sac_subdir: ''
 
-or via scripting
+  or via scripting
 
-.. code:: python
+  .. code:: python
 
-    sep = Pysep(sac_subdir='')
+      sep = Pysep(sac_subdir="")
 
-One useful example of this is if a User only wants to save SAC waveforms for
-the rotated RTZ component within their current working directory:
+* `Example`: if a User only wants to save SAC waveforms for the rotated RTZ
+  component within their current working directory, ignoring all automatically
+  generated sub directories, all other written files and all plots:
 
-.. code:: python
+  .. code:: python
 
-    sep = Pysep(overwrite_event_tag='', sac_subdir='', write_files='sac_rtz')
+      sep = Pysep(overwrite_event_tag="", sac_subdir="", write_files="sac_rtz",
+                  plot_files="")
 
 
 Output Filename Control
 ```````````````````````
 
+.. note::
+
+    The output SAC file names are hardcoded as trace IDs with or without the
+    event tag. If control over file IDs is a required feature, please open up a
+    GitHub issue.
+
 The event tag used to name the output directory and written SAC files can be set
-manually by the user using the `--event_tag` argument. If not given, the tag
-will default to a string consisting of event origin time and Flinn-Engdahl 
-region (or just origin time if `--legacy_naming` is used). Other output files
-such as the config file and ObsPy objects can be set as in the following: 
+manually by the user using the ``overwrite_event_tag`` argument.
+
+Other output file names can also be changed from their default values, see the
+:meth:`write function <pysep.pysep.Pysep.write>` for write file options and
+arguments to use for changing file names.
+
+An example of this via the command line:
 
 .. code:: bash
 
@@ -293,15 +255,57 @@ Or with scripting
     sep = Pysep(overwrite_event_tag="event_abc",
                 config_fid="event_abc.yaml", ...)
 
+
+Legacy Filenaming Schema
+````````````````````````
+
+The new version of PySEP uses a file naming schema that is incompatible with
+previous versions, which may lead to problems in established workflows.
+
+To honor the legacy naming schema of PySEP, simply use the ``legacy_naming``
+parameter. This will change how the event tag is formatted, how the output
+directory is structured, and how the output SAC files are named.
+
+.. code:: bash
+
+    pysep -c pysep_config.yaml --legacy_naming
+
+Or with scripting
+
+.. code:: python
+
+    sep = Pysep(legacy_naming=True, ...)
+
+
+Multiple Event Input
+--------------------
+
+To use the same configuration file with multiple events, you can use an event
+file passed to PySEP through the command line.
+
+When using this option, the event parameters inside the config file will be
+ignored, but all the other parameters will be used to gather data and metadata.
+
+Event input files should be text files where each row describes one event with
+the following parameters as columns:
+
+.. ORIGIN_TIME LONGITUDE LATITUDE DEPTH[KM] MAGNITUDE
+
+For an example event input file called 'event_input.txt', call structure is:
+
+.. code:: bash
+
+    pysep -c pysep_config.yaml -E event_input.txt
+
 .. note::
 
-    The output SAC file names are hardcoded as trace IDs and cannot be changed
-    by the user. If this is a required feature, please open up a GitHub issue,
-    and the developers will address this need.
+    Multiple event input is only available for command line usage of PySEP.
+    We suggest using a for loop if you would like to script multiple event
+    input using PySEP
 
 
 ObsPy Mass Downloader
-`````````````````````
+---------------------
 
 `ObsPy's Mass Download
 <https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.mass_downloader.html>`__

--- a/docs/pysep.rst
+++ b/docs/pysep.rst
@@ -153,22 +153,19 @@ class. See the PySEP docstring for input parameter types and definitions.
 -------------------------------------------------------------------------------
 
 
-Output Control
+PySEP Outputs
 --------------
 
-By default, PySEP writes all files to the User-defined parameter ``output_dir``,
-which defaults to the current working directory.
+PySEP uses a default directory structure when saving files:
 
-Files are normally written into a sub-directory defined by the ``event_tag``
-which is dynamically generated based on the event origin time, and Flinn-Engdahl
-region. For example:
-
-..
-
-    2009-04-07T201255_SOUTHERN_ALASKA
-
-All waveform files are saved in a further sub-directory ``SAC``, to avoid
-cluttering up the output directory.
+* ``output_dir``: By default, PySEP writes all files to the User-defined
+  parameter ``output_dir``, which defaults to the current working directory.
+* ``event_tag``: Files are written into a sub-directory defined by the event
+  origin time, and Flinn-Engdahl region. For example:
+  ``2009-04-07T201255_SOUTHERN_ALASKA``
+* ``sac_subdir``: All waveform files are saved in a further sub-directory
+  (default: `SAC/`), to avoid cluttering up the output directory. Waveform
+  files are tagged by the `event_tag` and trace ID.
 
 Users can use the parameters ``write_files`` and ``plot_files`` to control
 exactly what files are produced during a PySEP (see `API documentation
@@ -177,8 +174,8 @@ exactly what files are produced during a PySEP (see `API documentation
 By default, PySEP will write SAC files, StationXML, QuakeML and config files,
 and create a source-receiver map and record section.
 
-Directory Control
-`````````````````
+Override Directory Names
+````````````````````````
 
 In some cases it may be useful for Users to save files directly to their
 working directory, without all the automatically generated sub-directories.
@@ -196,6 +193,12 @@ working directory, without all the automatically generated sub-directories.
 
       sep = Pysep(overwrite_event_tag="")
 
+* To set your own event tag, use a string value
+
+  .. code:: bash
+
+        pysep -c pysep_config.yaml --overwrite_event_tag event_abc
+
 * To ignore the SAC subdirectory and save waveform files directly in the
   output directory, use the ``sac_subdir`` parameter, which should be input in
   your YAML parameter file:
@@ -208,7 +211,7 @@ working directory, without all the automatically generated sub-directories.
 
   .. code:: python
 
-      sep = Pysep(sac_subdir="")
+      sep = Pysep(sac_subdir="")  # or use a string value to define your own
 
 * `Example`: if a User only wants to save SAC waveforms for the rotated RTZ
   component within their current working directory, ignoring all automatically
@@ -220,14 +223,14 @@ working directory, without all the automatically generated sub-directories.
                   plot_files="")
 
 
-Output Filename Control
-```````````````````````
+Override Filenames
+``````````````````
 
 .. note::
 
-    The output SAC file names are hardcoded as trace IDs with or without the
-    event tag. If control over file IDs is a required feature, please open up a
-    GitHub issue.
+    The output SAC file names are hardcoded as trace IDs (with or without the
+    event tag). If additional control over file IDs is a required feature,
+    please open up a `GitHub issue <https://github.com/adjtomo/pysep/issues>`__
 
 The event tag used to name the output directory and written SAC files can be set
 manually by the user using the ``overwrite_event_tag`` argument.
@@ -283,6 +286,13 @@ Multiple Event Input
 To use the same configuration file with multiple events, you can use an event
 file passed to PySEP through the command line.
 
+.. note::
+
+    Multiple event input is only available for command line usage of PySEP.
+    We suggest using a for loop if you would like to script multiple event
+    input using PySEP
+
+
 When using this option, the event parameters inside the config file will be
 ignored, but all the other parameters will be used to gather data and metadata.
 
@@ -296,12 +306,6 @@ For an example event input file called 'event_input.txt', call structure is:
 .. code:: bash
 
     pysep -c pysep_config.yaml -E event_input.txt
-
-.. note::
-
-    Multiple event input is only available for command line usage of PySEP.
-    We suggest using a for loop if you would like to script multiple event
-    input using PySEP
 
 
 ObsPy Mass Downloader

--- a/docs/pysep.rst
+++ b/docs/pysep.rst
@@ -201,6 +201,12 @@ Or with scripting
     sep = Pysep(legacy_naming=True, ...)
 
 
+Output Directory Control
+------------------------
+
+By default, PySEP
+
+
 Output Filename Control
 ```````````````````````
 

--- a/docs/pysep.rst
+++ b/docs/pysep.rst
@@ -201,10 +201,70 @@ Or with scripting
     sep = Pysep(legacy_naming=True, ...)
 
 
-Output Directory Control
-------------------------
+Output Control
+--------------
 
-By default, PySEP
+By default, PySEP writes all files to the User-defined parameter `output_dir`,
+which defaults to the current working directory.
+
+Files are normally written into a sub-directory defined by the `event_tag` which
+is dynamically generated based on the event origin time, and its Flinn-Engdahl
+region. For example
+
+.. code::
+
+    2009-04-07T201255_SOUTHERN_ALASKA
+
+All waveform files are saved in a further sub-directory `SAC`, to avoid
+cluttering up the output directory.
+
+.. note::
+
+    Users can use the parameters `write_files` and `plot_files` to control
+    exactly what files are produced during a PySEP (`see API documentation
+    <autoapi/pysep/pysep/index.html#pysep.pysep.Pysep>`__).
+
+By default, PySEP will write SAC files, StationXML, QuakeML and config files,
+and create a source-receiver map and record section.
+
+Directory Control
+-----------------
+
+In some cases it may be useful for Users to save files directly to their
+working directory, without all the automatically generated sub-directories.
+
+To ignore the automatically generated event tag, you can use the
+`overwrite_event_tag` parameter. Via the command line:
+
+.. code:: bash
+
+    pysep -c pysep_config.yaml --overwrite_event_tag ''
+
+Or via scripting:
+
+.. code:: python
+
+    sep = Pysep(overwrite_event_tag='')
+
+To save waveform files directly in the output directory, use the `sac_subdir`
+parameter, which should be input in your YAML parameter file:
+
+.. code:: yaml
+
+    sac_subdir: ''
+
+or via scripting
+
+.. code:: python
+
+    sep = Pysep(sac_subdir='')
+
+One useful example of this is if a User only wants to save SAC waveforms for
+the rotated RTZ component within their current working directory:
+
+.. code:: python
+
+    sep = Pysep(overwrite_event_tag='', sac_subdir='', write_files='sac_rtz')
 
 
 Output Filename Control
@@ -233,10 +293,9 @@ Or with scripting
     sep = Pysep(overwrite_event_tag="event_abc",
                 config_fid="event_abc.yaml", ...)
 
-
 .. note::
 
-    The output SAC file names are hardcoded and cannot be changed
+    The output SAC file names are hardcoded as trace IDs and cannot be changed
     by the user. If this is a required feature, please open up a GitHub issue,
     and the developers will address this need.
 

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1588,28 +1588,41 @@ class Pysep:
         # probably these will overwrite already written files
         if "sac_zne" in write_files:
             logger.info("writing ZNE waveforms traces in SAC format")
-            self._write_sac(st=self.st.select(channel="ZNE"),
-                            output_dir=_output_dir)
+            self._write_sac(st=self.st, output_dir=_output_dir,
+                            components="ZNE")
 
         if "sac_rtz" in write_files:
+            import pdb;pdb.set_trace()
             logger.info("writing RTZ waveforms traces in SAC format")
-            self._write_sac(st=self.st.select(channel="RTZ"),
-                            output_dir=_output_dir)
+            self._write_sac(st=self.st, output_dir=_output_dir,
+                            components="RTZ")
 
         if "sac_uvw" in write_files:
             logger.info("writing UVW waveforms traces in SAC format")
-            self._write_sac(st=self.st.select(channel="UVW"),
-                            output_dir=_output_dir)
+            self._write_sac(st=self.st, output_dir=_output_dir,
+                            components="UVW")
 
-    def _write_sac(self, st, output_dir=os.getcwd()):
+    def _write_sac(self, st, output_dir=os.getcwd(), components=None):
         """
         Write SAC files with a specific naming schema, which allows for both
         legacy (old PySEP) or non-legacy (new PySEP) naming.
+
+        :type st: obspy.core.stream.Stream
+        :param st: Stream to be written
+        :type output_dir: str
+        :param output_dir: where to save the SAC files, defaults to the
+            current working directory
+        :type components: str
+        :param components: acceptable component values for saving files,
+            allows only saving subsets of the Stream. Example 'RTZNE' or
+            just 'R'. Must match against Trace.stats.component
         """
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 
         for tr in st:
+            if components and tr.stats.component not in components:
+                continue
             if self._legacy_naming:
                 # Legacy: e.g., 20000101000000.NN.SSS.LL.CC.c
                 _trace_id = f"{tr.get_id()[:-1]}.{tr.get_id()[-1].lower()}"
@@ -1785,7 +1798,7 @@ class Pysep:
             else:
                 self.inv = inv
             self.inv = self.curtail_stations()
-            self.write(write_files=["inv"], **kwargs)  # write out inventory
+            self.write(_subset=["inv"], **kwargs)  # write out inventory
 
             # Get waveforms, format and assess waveform quality
             if st is None:

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1489,6 +1489,9 @@ class Pysep:
                 defaults to 'event.xml'
             stream_fid (str): optional name for saved ObsPy Stream miniseed
                 object, defaults to 'stream.ms'
+            sac_subdir (str): sub-directory within output directory and event
+                directory to save SAC files. Defaults to SAC/. Use an empty
+                string to dump files directly into the event directory
         """
         # Set some default values that can be overridden with kwargs
         order_station_list_by = self.kwargs.get("order_station_list_by", None)
@@ -1497,6 +1500,7 @@ class Pysep:
         inv_fid = self.kwargs.get("inv_fid", "inv.xml")
         event_fid = self.kwargs.get("event_fid", "event.xml")
         stream_fid = self.kwargs.get("stream_fid", "stream.ms")
+        sac_subdir = self.kwargs.get("sac_subdir", "SAC")
 
         # This is defined here so that all these filenames are in one place,
         # but really this set is just required by check(), not by write()
@@ -1568,7 +1572,7 @@ class Pysep:
         if self._legacy_naming:
             _output_dir = self.output_dir
         else:
-            _output_dir = os.path.join(self.output_dir, "SAC")
+            _output_dir = os.path.join(self.output_dir, sac_subdir)
 
         if "sac_raw" in write_files:
             logger.info("writing RAW waveforms traces in SAC format")

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -39,7 +39,7 @@ from pysep.utils.curtail import (curtail_by_station_distance_azimuth,
                                  remove_traces_w_masked_data
                                  )
 from pysep.utils.fmt import format_event_tag, format_event_tag_legacy, get_codes
-from pysep.utils.io import read_yaml, read_event_file, write_pysep_stations_file
+from pysep.utils.io import read_yaml, read_event_file, write_pysep_station_file
 from pysep.utils.llnl import scale_llnl_waveform_amplitudes
 from pysep.utils.process import (merge_gapped_data, trim_start_end_times,
                                  resample_data, format_streams_for_rotation,
@@ -1413,7 +1413,7 @@ class Pysep:
         return st_out
 
     def write(self, write_files=None, _return_filenames=False,
-              config_fid=None, stations_fid=None, inv_fid=None, event_fid=None,
+              config_fid=None, station_fid=None, inv_fid=None, event_fid=None,
               stream_fid=None, **kwargs):
         """
         Write out various files specifying information about the collected
@@ -1444,8 +1444,8 @@ class Pysep:
         :type config_fid: str
         :param config_fid: optional name for the configuration file name
             defaults to 'pysep_config.yaml'
-        :type stations_fid: str
-        :param stations_fid: optional name for the stations list file name
+        :type station_fid: str
+        :param station_fid: optional name for the stations list file name
             defaults to 'station_list.txt'
         :type inv_fid: str
         :param inv_fid: optional name for saved ObsPy inventory object,
@@ -1492,10 +1492,10 @@ class Pysep:
 
         if "station_list" in write_files or "all" in write_files:
             fid = os.path.join(self.output_dir,
-                               stations_fid or "station_list.txt")
+                               station_fid or "station_list.txt")
             logger.info("writing stations file")
             logger.debug(fid)
-            write_pysep_stations_file(
+            write_pysep_station_file(
                     self.inv, self.event, fid, 
                     order_station_list_by=order_station_list_by
                     )

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1477,22 +1477,28 @@ class Pysep:
 
         Keyword Arguments
         ::
-            order_station_list_by (str): how to order the station list
-                available options are: network, station, latitude, longitude,
-                elevation, burial.
-            config_fid (str): optional name for the configuration file name
-                defaults to 'pysep_config.yaml'
-            station_fid (str): optional name for the stations list file name
-                defaults to 'station_list.txt'
-            inv_fid (str): optional name for saved ObsPy inventory object,
-                defaults to 'inv.xml'
-            event_fid (str): optional name for saved ObsPy Event object,
-                defaults to 'event.xml'
-            stream_fid (str): optional name for saved ObsPy Stream miniseed
-                object, defaults to 'stream.ms'
-            sac_subdir (str): sub-directory within output directory and event
-                directory to save SAC files. Defaults to SAC/. Use an empty
-                string to dump files directly into the event directory
+            str order_station_list_by:
+                how to order the station list available options are:
+                network, station, latitude, longitude, elevation, burial.
+            str config_fid:
+                optional name for the configuration file name defaults to
+                'pysep_config.yaml'
+            str station_fid:
+                optional name for the stations list file name defaults to
+                'station_list.txt'
+            str inv_fid:
+                optional name for saved ObsPy inventory object, defaults to
+                'inv.xml'
+            str event_fid:
+                optional name for saved ObsPy Event object, defaults to
+                'event.xml'
+            str stream_fid:
+                optional name for saved ObsPy Stream miniseed object,
+                defaults to 'stream.ms'
+            str sac_subdir:
+                sub-directory within output directory and event directory to
+                save SAC files. Defaults to SAC/. Use an empty string to dump
+                files directly into the event directory
         """
         # Set some default values that can be overridden with kwargs
         order_station_list_by = self.kwargs.get("order_station_list_by", None)
@@ -1592,7 +1598,6 @@ class Pysep:
                             components="ZNE")
 
         if "sac_rtz" in write_files:
-            import pdb;pdb.set_trace()
             logger.info("writing RTZ waveforms traces in SAC format")
             self._write_sac(st=self.st, output_dir=_output_dir,
                             components="RTZ")

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -142,6 +142,20 @@ class Pysep:
         :param event_longitude: longitude of the event in units of degrees.
             used for defining the event hypocenter and for removing stations
             based on distance from the event.
+        :type event_depth_km: float
+        :param event_depth_km: depth of event in units of kilometers. postive
+            values for deeper depths. Used for:
+
+            1) `event_selection`=='search'
+            2) estimating phase arrivals with TauP
+            3) plotting events and title on source receiver maps
+
+            If set to None, (2) and (3) will fail. Best-guesses are acceptable.
+        :type event_magnitude: float
+        :param event_magnitude: event magnitude in Mw used for:
+
+            1) `event_selection`=='search'
+            2)
         :type seconds_before_event: float
         :param seconds_before_event: For event selection only, only used if
             `event_selection`=='search'. Time [s] before given `origin_time` to
@@ -380,7 +394,7 @@ class Pysep:
             - weights_az: write out CAP weight file sorted by azimuth
             - weights_dist: write out CAP weight file sorted by distance
             - weights_code: write out CAP weight file sorted by station code
-            - station_list: write out a text file with station informatino
+            - station_list: write out a text file with station information
             - inv: save a StationXML (.xml) file (ObsPy inventory)
             - event: save a QuakeML (.xml) file (ObsPy Catalog)
             - stream: save an ObsPy stream in Mseed (.ms) (ObsPy Stream)

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1456,7 +1456,7 @@ class Pysep:
             defaults to 'stream.ms'
         """
         # Collect kwargs for writing
-        order_stations_list_by = kwargs.get("order_stations_list_by", None)
+        order_station_list_by = kwargs.get("order_station_list_by", None)
 
         # This is defined here so that all these filenames are in one place,
         # but really this set is just required by check(), not by write()
@@ -1492,12 +1492,12 @@ class Pysep:
 
         if "station_list" in write_files or "all" in write_files:
             fid = os.path.join(self.output_dir,
-                               stations_fid or "stations_list.txt")
+                               stations_fid or "station_list.txt")
             logger.info("writing stations file")
             logger.debug(fid)
             write_pysep_stations_file(
                     self.inv, self.event, fid, 
-                    order_stations_list_by=order_stations_list_by
+                    order_station_list_by=order_station_list_by
                     )
 
         if "inv" in write_files or "all" in write_files:

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1521,8 +1521,10 @@ class RecordSection:
                 self.kwargs[name] = val
         self.ax = set_plot_aesthetic(ax=self.ax, **self.kwargs)
 
-        # Partition the figure by user-specified azimuth bins
-        if self.sort_by and "azimuth" in self.sort_by:
+        # Partition the figure by user-specified azimuth bins for relative
+        # (back)azimuth sorting only (not absolute)
+        if self.sort_by and ("azimuth" in self.sort_by) and \
+                ("abs_" not in self.sort_by):
             self._plot_azimuth_bins(start=start, stop=stop)
 
         # Finalize the figure accoutrements

--- a/pysep/utils/io.py
+++ b/pysep/utils/io.py
@@ -559,8 +559,8 @@ def write_sem(st, unit, path="./", time_offset=0):
         np.savetxt(fid, data, ["%13.7f", "%17.7f"])
 
 
-def write_pysep_stations_file(inv, event, fid="./stations_list.txt", 
-                              order_stations_list_by=None):
+def write_pysep_station_file(inv, event, fid="./station_list.txt", 
+                             order_station_list_by=None):
     """
     Write a list of station codes, distances, etc. useful for understanding
     characterization of all collected stations
@@ -572,20 +572,20 @@ def write_pysep_stations_file(inv, event, fid="./stations_list.txt",
     :param inv: optional user-provided inventory object which will force a
         skip over StationXML/inventory searching
     :type fid: str
-    :param fid: name of the file to write to. defaults to ./stations_list.txt
-    :type order_by: str
-    :param order_by: how to order the stations written to file. Available
-        are: network, station, latitude, longitude, elevation, burial.
+    :param fid: name of the file to write to. defaults to ./station_list.txt
+    :type order_station_list_by: str
+    :param order_station_list_by: how to order the stations written to file.
+        Available are: network, station, latitude, longitude, elevation, burial.
         If not given, order is determined by the internal sorting of the
         input Inventory
     """
     # Key indices correspond to stations list
     keys = ["station", "network", "latitude", "longitude", "distance",
             "azimuth"]
-    if order_stations_list_by and order_stations_list_by not in keys:
-        logger.warning(f"`order_stations_by` must be in {keys}, "
+    if order_station_list_by and order_station_list_by not in keys:
+        logger.warning(f"`order_station_by` must be in {keys}, "
                        f"setting default")
-        order_stations_by = None
+        order_station_by = None
 
     event_latitude = event.preferred_origin().latitude
     event_longitude = event.preferred_origin().longitude
@@ -603,8 +603,8 @@ def write_pysep_stations_file(inv, event, fid="./stations_list.txt",
                              dist_km, az])
 
     # Set the order of the station file based on the order of keys
-    if order_stations_list_by:
-        idx = keys.index(order_stations_list_by)
+    if order_station_list_by:
+        idx = keys.index(order_station_list_by)
         stations.sort(key=lambda x: x[idx])
 
     with open(fid, "w") as f:
@@ -677,6 +677,7 @@ def write_stations_file(inv, fid="./STATIONS", order_by=None,
             f.write(f"{s[0]:>6}{s[1]:>6}{s[2]:12.4f}{s[3]:12.4f}"
                     f"{s[4]:7.1f}{s[5]:7.1f}\n"
                     )
+
 
 def write_cat_to_event_list(cat, fid_out="event_input.txt"):
     """

--- a/pysep/utils/io.py
+++ b/pysep/utils/io.py
@@ -302,7 +302,7 @@ def read_specfem3d_cmtsolution_cartesian(path_to_cmtsolution):
     with open(path_to_cmtsolution, "r") as f:
         lines = f.readlines()
 
-    # First line contains meta informatino about event
+    # First line contains meta information about event
     _, year, month, day, hour, minute, sec, lat, lon, depth, mb, ms, _ = \
         lines[0].strip().split()
 


### PR DESCRIPTION
Related to #75, #77
Internal rewriting of PySEP's file writing system to be more flexible and useful. Also minor typo fixes and bugfixes piggybacking

### Major Changelog (default behavior changes)
- Changed default files that are written out by PySEP ("inv,event,stream,sac,config_file,station_list")
- No longer write out ``weights*.dat`` files by default, User must request using ``write_files``='all' or ``write_files``='weights_dist'
- Files are written out **when available** and not at the end of the workflow  #77 
- Log file (same as is printed to stdout) is written out as ``pysep.log`` #77 

### Minor Changelog:
- Turn off azimuth bins when sorting by absolute (back)azimuth  #75 
- Output stations file: `stations_file.txt` -> `station_file.txt`
- Allow User to bypass ``event_tag`` subdirectory  #77
- Allow User to bypass ``SAC`` waveform subdirectory  #77
- Added PySEP docs section to explain how to use subdirectory bypass
- Allow User to write out only specific components ('ZNE', 'RTZ', 'UVW') by passing parameter ``write_files``=='sac_rtz' (for example)  #77 