### PR TITLE
General Improvements: improve recsec log, single-source version, bugfix zero trace length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,25 @@
   - PySEP warns when config parameters are not used by the program
 
 
-## Version 0.4.1 (Master/Devel)
+## Version 0.4.1 (Master)
 - Adds Tutorial documentation following GEOS626 lab (thanks, Aakash!)
 - Adds version release documentation
 - Slightly modifies pysep-docs conda environment to accomodate converted nbooks
+
+## Version 0.5.0 (Devel)
+- Improves functions 'read_forcesolution' and 'read_source', which now return
+  `obspy.core.event.Event` objects, rather than the makeshift Source objects 
+- 'read_forcesolution' can now handle FORCESOLUTION files from both SPECFEM3D
+  and SPECFEM3D_GLOBE
+- Added function `read_events_plus` that provides additional support to 
+  Obspys `read_events` function by allowing for support of FORCESOLUTION and
+  SOURCE files from SPECFEM2D/3D/3D_GLOBE
+- Remove the `Source` class from `Pysep.utils.io.mt`. This was a remnant of the
+  old Pyatoa approach to building an Obspy Event-like object to mimic certain
+  behaviors. This has been replaced by read functions which simply return Events
+- #117: New quality control function that removes Traces with array length <= 1,
+  which would cause preprocessing to fail
+- #116: RecSec now logs absmax amplitudes and absmax amplitude ratios IFF both
+  `st` and `st_syn` are provided
+- #120: Version number is now only sourced from `pyproject.toml`, other 
+  locations now reference this file to determine version number

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,8 @@ release = ''
 with open("../pyproject.toml", "r") as f:
     _lines = f.readlines()
 for _line in _lines:
-    if line.startswith("version"):
-        version = line.split('"')[1].strip()
+    if _line.startswith("version"):
+        version = _line.split('"')[1].strip()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ project = 'PySEP'
 copyright = '2023, adjTomo Dev Team'
 author = 'adjTomo Dev Team'
 release = ''
-version = '0.4.1'
+version = '0.5.0-dev'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,12 @@ project = 'PySEP'
 copyright = '2023, adjTomo Dev Team'
 author = 'adjTomo Dev Team'
 release = ''
-version = '0.5.0-dev'
+# Grab version number from 'pyproject.toml'
+with open("../pyproject.toml", "r") as f:
+    _lines = f.readlines()
+for _line in _lines:
+    if line.startswith("version"):
+        version = line.split('"')[1].strip()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/how_to_version_release.md
+++ b/docs/how_to_version_release.md
@@ -8,8 +8,6 @@ patch), or provide reason in PR for why certain points are not checked.
 ## Prior to PR merge:
 - [ ] Merge `devel` -> `master`
 - [ ] Bump version number `pyproject.toml`
-- [ ] Bump version number `docs/conf.py`
-- [ ] Bump version number `pysep/__init__.py`
 - [ ] Ensure all tests still pass, fix broken tests
 - [ ] Update `CHANGELOG` to include all major changes since last version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysep-adjtomo"
-version = "0.5.0-dev"
+version = "0.5.0"
 description = "Python Seismogram Extraction and Processing"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE.txt"}
 authors = [
     {name = "adjTomo Dev Team"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysep-adjtomo"
-version = "0.4.1"
+version = "0.5.0-dev"
 description = "Python Seismogram Extraction and Processing"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pysep/__init__.py
+++ b/pysep/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.4.1"
+__version__ = "0.5.0-dev"
 
 logger = logging.getLogger("pysep")
 logger.setLevel("INFO")

--- a/pysep/__init__.py
+++ b/pysep/__init__.py
@@ -1,6 +1,8 @@
 import logging
+from importlib.metadata import version
 
-__version__ = "0.5.0-dev"
+# Defines version number from 'pyproject.toml'
+__version__ = version("pysep-adjtomo")
 
 logger = logging.getLogger("pysep")
 logger.setLevel("INFO")

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1595,21 +1595,26 @@ class RecordSection:
         """
         log_str = (
             "relative amplitude information"
-            f"\nIDX{'[O]BS':>13}{'[S]YN':>15}{'O_MAX':>12}{'S_MAX':>12}  "
-            f"{'O_MAX/S_MAX':>12} {'LN(O_MAX/S_MAX)':>15}\n"
+            f"\nIDX{'[O]BS':>13}{'[S]YN':>15}"
+            f"{'[O_A]BSMAX':>15}{'[S_A]BSMAX':>12}  "
+            f"{'O_A/S_A':>8}{'LN(O_A/S_A)':>14}\n"
         )
         for idx in self.sorted_idx[start:stop]:
             tr = self.st[idx]
             tr_syn = self.st_syn[idx]
 
+            # Get absolute maximum value of both obs and syn traces
+            tr_max = np.abs(tr.max())
+            tr_syn_max = np.abs(tr_syn.max())
+
             log_str += (
-                f"{idx:>3}"
+                f"{idx:<3}"
                 f"{tr.get_id():>15}"
                 f"{tr_syn.get_id():>15}"
-                f"{tr.data.max():12.2E}"
-                f"{tr_syn.data.max():12.2E}"
-                f"{tr.data.max() / tr_syn.data.max():12.2E}"
-                f"{np.log(tr.data.max() / tr_syn.data.max()):12.2E}\n"
+                f"{tr_max:12.2E}"
+                f"{tr_syn_max:12.2E}"
+                f"{tr_max / tr_syn_max:12.2E}"
+                f"{np.log(tr_max / tr_syn_max):12.2E}\n"
             )
         logger.debug(log_str)
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -489,7 +489,7 @@ def estimate_prefilter_corners(tr):
     # filtering constants
     fcut1_par = 4.0
     fcut2_par = 0.5
-
+    
     f1 = fcut1_par / (tr.stats.endtime - tr.stats.starttime)
     nyquist_freq = tr.stats.sampling_rate / 2
     f2 = nyquist_freq * fcut2_par


### PR DESCRIPTION
- #117: New quality control function that removes Traces with array length <= 1, which would cause preprocessing to fail
- #116: RecSec now logs absmax amplitudes and absmax amplitude ratios IFF both `st` and `st_syn` are provided
- #120: Version number is now only sourced from `pyproject.toml`, other locations now reference this file to determine version number
- Bumps version number to 0.5.0 for the latest `Devel` branch