### PR TITLE
Bugfix: incorrect RecSec xlim_s indexing

### DIFF
--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -802,8 +802,10 @@ class RecordSection:
         # zoomed in on the P-wave, max amplitude should NOT be the surface wave)
         for tr, xlim in zip(self.st, self.xlim):
             start, stop = xlim
-            start = int(start * tr.stats.sampling_rate)
-            stop = int(stop * tr.stats.sampling_rate)
+            if start:
+                start = int(start * tr.stats.sampling_rate)
+            if stop:
+                stop = int(stop * tr.stats.sampling_rate)
             self.max_amplitudes = np.append(self.max_amplitudes,
                                             max(abs(tr.data[start:stop])))
         self.max_amplitudes = np.array(self.max_amplitudes)
@@ -813,8 +815,10 @@ class RecordSection:
         if self.st_syn is not None:
             for tr, xlim in zip(self.st_syn, self.xlim):
                 start, stop = xlim
-                start = int(start * tr.stats.sampling_rate)
-                stop = int(stop * tr.stats.sampling_rate)
+                if start:
+                    start = int(start * tr.stats.sampling_rate)
+                if stop:
+                    stop = int(stop * tr.stats.sampling_rate)
                 self.max_amplitudes_syn = np.append(
                         self.max_amplitudes_syn, max(abs(tr.data[start:stop]))
                         )

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -802,6 +802,8 @@ class RecordSection:
         # zoomed in on the P-wave, max amplitude should NOT be the surface wave)
         for tr, xlim in zip(self.st, self.xlim):
             start, stop = xlim
+            start = int(start * tr.stats.sampling_rate)
+            stop = int(stop * tr.stats.sampling_rate)
             self.max_amplitudes = np.append(self.max_amplitudes,
                                             max(abs(tr.data[start:stop])))
         self.max_amplitudes = np.array(self.max_amplitudes)
@@ -811,6 +813,8 @@ class RecordSection:
         if self.st_syn is not None:
             for tr, xlim in zip(self.st_syn, self.xlim):
                 start, stop = xlim
+                start = int(start * tr.stats.sampling_rate)
+                stop = int(stop * tr.stats.sampling_rate)
                 self.max_amplitudes_syn = np.append(
                         self.max_amplitudes_syn, max(abs(tr.data[start:stop]))
                         )


### PR DESCRIPTION
The RecordSection parameter `xlim_s`, when used in conjunction with the 'scale_by' == `normalize` would identify the section of waveform to check max amplitudes, with which it would normalize the remainder of the trace. 

Previously it was selecting sections of the waveform using the time value from `xlim_s`, rather than the index value required (time * sampling rate), which caused the incorrect section of waveform to be used for trace normalization. 

This PR fixes this bug by converting the time values in `xlim_s` to index values for selecting max amplitudes fro trace normalization