### PR TITLE
Bugfix RecSec ZeroDivisionError on trace normalization

### DIFF
--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1698,6 +1698,8 @@ class RecordSection:
         linewidth = self.kwargs.get("linewidth", .25)
         window_alpha = self.kwargs.get("window_alpha", .1)
         window_color = self.kwargs.get("window_color", "orange")
+        obs_color = self.kwargs.get("obs_color", "k")
+        syn_color = self.kwargs.get("syn_color", "r")
 
         # Used to differentiate the two types of streams for plotting diffs
         choices = ["st", "st_syn"]
@@ -1739,7 +1741,14 @@ class RecordSection:
             amplitude_scaling = self.amplitude_scaling_syn
             max_amplitudes = self.max_amplitudes_syn
 
-        y = sign * tr.data / amplitude_scaling[idx] + self.y_axis[y_index]
+        # Avoid ZeroDivisionError if the amplitude scaling value is 0 (#131)
+        scale = amplitude_scaling[idx]
+        if scale == 0:
+            logger.warning("amplitude scaling value is 0, setting to 1, "
+                           "amplitude scaling may not behave as expected")
+            scale = 1
+
+        y = sign * tr.data / scale + self.y_axis[y_index]
 
         # Experimental: Plot windows over the record section if provided by User
         if self.windows and tr.id in self.windows:
@@ -1760,8 +1769,9 @@ class RecordSection:
 
         x = x[start:stop]
         y = y[start:stop]
-        self.ax.plot(x, y, c=["k", "r"][c], linewidth=linewidth, zorder=10)
-
+        self.ax.plot(x, y, c=[obs_color, syn_color][c], linewidth=linewidth, 
+                     zorder=10)
+        
         # Sanity check print station information to check against plot
         log_str = (f"{idx}"
                    f"\t{int(self.y_axis[y_index])}"

--- a/pysep/tests/test_recsec.py
+++ b/pysep/tests/test_recsec.py
@@ -137,3 +137,24 @@ def test_recsec_calc_time_offset(recsec_w_synthetics):
     recsec_w_synthetics.get_parameters()
     for tr in recsec_w_synthetics.st:
         assert(tr.stats.time_offset == -100)
+
+def test_recsec_zero_amplitude(recsec):
+    """
+    waveforms that have zero amplitude and are normalized should be able 
+    to bypass normalizations which lead to weird plotting (see #131).
+
+    .. note::
+
+        This does not really test that the method is working correctly because
+        dividing a NumPy array by zero leads to NaNs in the array which just
+        won't plot. This is more of a visual test to make sure that the 
+        zero amplitude is plotting correctly, look for green lines
+    """
+    recsec.kwargs.scale_by = "normalize"
+    recsec.kwargs.obs_color = "green"
+    recsec.linewidth = 30
+    for tr in recsec.st:
+        tr.data *= 0
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()


### PR DESCRIPTION
Small RecSec PR to address #131 concerning zero amplitude traces. Previously, zero amplitude normalization would cause the NumPy trace arrays to become NaNs which would not plot, but would allow RecSec to continue running. There are now some guardrails in place to prevent these arrays from becoming NaNs.

### Changelog:
- If RecSec tries to normalize by 0, throws a warning and normalizes by 1 instead. May have unintentional consequences, but allows waveforms to be plotted
- Feature: user can now set RecSec kwargs for `obs_color` and `syn_color` to change the color of observed and synthetic waveforms, previously these were hardcoded to black and red, respectively.
- Adds Test to cover this case, not a great test but it atleast runs the case where amplitudes are 0, and will require a visual check to ensure that the waveforms are actual plotting.