### PR TITLE
Improve SAC header append functions

### DIFF
--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -176,6 +176,14 @@ def test_read_sem():
         st += read_sem(fid=test_synthetic, source=test_cmtsolution,
                        stations=test_stations)
     assert(st)
+
+    expected_headers = ["iztype", "b", "e", "evla", "evlo", "stla", "stlo", 
+                        "stel", "kevnm", "nzyear", "nzjday", "nzhour", "nzmin", 
+                        "nzsec", "nzmsec", "dist", "az", "baz", "gcarc", 
+                        "lpspol", "lcalda", "evdp", "mag"]
+    for expected_header in expected_headers:
+        assert(expected_header in st[0].stats.sac)
+
     assert(st[0].stats.sac.evla == -40.5405)
 
 
@@ -192,8 +200,17 @@ def test_read_sem_cartesian():
         st += read_sem(fid=test_synthetic, source=test_cmtsolution,
                        stations=test_stations)
     assert(st)
+
+    expected_headers = ["iztype", "b", "e", "evla", "evlo", "stla", "stlo", 
+                        "kevnm", "nzyear", "nzjday", "nzhour", "nzmin", 
+                        "nzsec", "nzmsec", "dist", "az", "baz", "gcarc", 
+                        "lpspol", "lcalda", "evdp"]
+    for expected_header in expected_headers:
+        assert(expected_header in st[0].stats.sac)
+
     assert(st[0].stats.sac.stla == 67000.0)
-    assert("evdp" in st[0].stats.sac)
+    assert(st[0].stats.sac.evdp == 30.)
+    assert(st[0].stats.sac.b == -10.)
 
 def test_estimate_prefilter_corners(test_st):
     """

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -59,6 +59,16 @@ def test_append_sac_headers(test_st, test_inv, test_event):
     assert(st[0].stats.sac["evla"] == test_event.preferred_origin().latitude)
 
 
+def test_append_sac_headers_cartesian(test_st, test_inv, test_event):
+    """
+    Make sure we can write SAC headers correctly
+    """
+    st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
+    assert(not hasattr(test_st[0].stats, "sac"))
+    assert(hasattr(st[0].stats, "sac"))
+    assert(st[0].stats.sac["evla"] == test_event.preferred_origin().latitude)
+
+
 def test_event_tag_and_event_tag_legacy(test_event):
     """
     Check that event tagging works as expected
@@ -183,6 +193,7 @@ def test_read_sem_cartesian():
                        stations=test_stations)
     assert(st)
     assert(st[0].stats.sac.stla == 67000.0)
+    assert("evdp" in st[0].stats.sac)
 
 def test_estimate_prefilter_corners(test_st):
     """

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -219,12 +219,14 @@ def _append_sac_headers_trace(tr, event, inv):
         evdp = event.preferred_origin().depth / 1E3  # units: km
         sac_header["evdp"] = evdp
     except Exception:  # NOQA
+        logger.warning("no event depth available for SAC header")
         pass
 
     try:
         mag = event.preferred_magnitude().mag
         sac_header["mag"] = mag
     except Exception:  # NOQA
+        logger.warning("no event magnitude available for SAC header")
         pass
 
     # Append SAC header and include back azimuth for rotation


### PR DESCRIPTION
Related to #132, original SAC header functions for SPECFEM synthetics were very barebones, just providing enough information for RecSec to take over and plot. However it is beneficial to include all available SAC headers since the code was already written for normal data.

### CHANGELOG
- `append_sac_headers_cartesian` now includes all SAC header values found in `append_sac_headers` except for `cmpinc` and `cmpaz` which are component based inclination and azimuth and not really necessary for synthetics
- Added some improved log warnings for normal SAC header to warn User when optional parameters like `evdp` were not appended, previously these passed through silently
- Improved tests to catch new functionalities