### PR TITLE
Improve preprocessing architecture

### DIFF
--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1501,8 +1501,7 @@ class RecordSection:
 
         return xtick_minor, xtick_major
 
-    def process_st(self, max_percentage=0.05, zerophase=True, 
-                   taper_type="cosine", fill_value="mean"):
+    def process_st(self, **kwargs):
         """
         Preprocess the Stream with optional filtering in place.
 
@@ -1518,6 +1517,7 @@ class RecordSection:
         TODO Add feature to allow list-like periods to individually filter
             seismograms. At the moment we just apply a blanket filter.
 
+        KWARGS
         :type max_percentage: float
         :param max_percentage: percentage of the trace to taper at both ends
         :type zerophase: bool
@@ -1529,6 +1529,11 @@ class RecordSection:
         :param fill_value: value to fill gaps in the data after trimming, 
             defaults to mean of the trace
         """
+        max_percentage = float(self.kwargs.get("max_percentage", 0.05))
+        zerophase = bool(self.kwargs.get("zerophase", True))
+        taper_type = self.kwargs.get("taper_type", "cosine")
+        fill_value = self.kwargs.get("fill_value", "mean")
+
         # Determine which traces we are running through preprocessing
         if self.preprocess == False:
             logger.info("no preprocessing will be applied to waveforms")
@@ -1548,8 +1553,8 @@ class RecordSection:
 
         for st in preprocess_list:
             if self.trim:
-                logger.debug("trimming start and end times and filling gaps "
-                            f"with {fill_value}")
+                logger.debug("trimming start and end times and filling any "
+                             f"gaps with {fill_value}")
                 for tr in st:
                     if fill_value == "mean":
                         fill_value = tr.data.mean()

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -326,7 +326,6 @@ class RecordSection:
         :param min_period_s: minimum filter period in seconds
         :type max_period_s: float
         :param max_period_s: maximum filter period in seconds
-
         :type integrate: int
         :param integrate: apply integration `integrate` times on all traces.
             acceptable values [-inf, inf], where positive values are integration
@@ -727,23 +726,23 @@ class RecordSection:
                 len(self.amplitude_scale_factor) != len(self.st):
             err.amplitude_scale_factor = f"must be list length {len(self.st)}"
 
+        acceptable_preprocess = [True, False, "st", "st_syn"]
+        if self.preprocess not in acceptable_preprocess:
+            err.preprocess = f"must be in {acceptable_preprocess}"
+
+        if self.preprocess in ["st_syn", True]:
+            assert(self.st is not None and self.st_syn is not None), (
+                f"`preprocess` choice requires both `st` & `st_syn` to exist."
+                f"If you only have one or the other, set: `preprocess`=='st'"
+            )
+
         if self.min_period_s is not None and self.max_period_s is not None:
             if self.min_period_s >= self.max_period_s:
                 err.min_period_s = "must be less than `max_period_s`"
 
         if self.min_period_s is not None or self.max_period_s is not None:
-            assert(self.preprocess is not None), \
+            assert(self.preprocess is not False), \
                 f"Setting filter bounds requires `preprocess` flag to be set"
-
-        if self.preprocess is not None:
-            acceptable_preprocess = ["both", "st", "st_syn"]
-            if self.preprocess not in acceptable_preprocess:
-                err.preprocess = f"must be in {acceptable_preprocess}"
-        if self.preprocess in ["st_syn", "both"]:
-            assert(self.st is not None and self.st_syn is not None), (
-                f"`preprocess` choice requires both `st` & `st_syn` to exist."
-                f"If you only have one or the other, set: `preprocess`=='st'"
-            )
 
         # Overwrite the max traces per record section, enforce type int
         if self.max_traces_per_rs is None:


### PR DESCRIPTION
Related to #133, current preprocessing is a bit obfuscated behind a single `preprocess` flag which is off by default and must be turned on by the User, and then preprocessing is either all or nothing, with no knobs to turn off individual features. This PR tries to imrove this system by adding a few more knobs and trying to make the preprocess experience a bit more streamlined.

### ChangeLog

