### PR TITLE
Hotfix: CAP weight file sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,8 @@
 - #137: More control over RecSec kwargs and better warning messages
 - #138: Improved SAC header creation for SPECFEM synthetics
 - #139: Improved RecSec preprocessing setup, more manual control for the User 
+
+## Version 0.6.1
+
+- Change log level from warning -> info for empty origin time when reading SPECFEM sources
+- Remove README doc page about publishing to PyPi, moved this to adjDocs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,3 +127,5 @@
 
 - Change log level from warning -> info for empty origin time when reading SPECFEM sources
 - Remove README doc page about publishing to PyPi, moved this to adjDocs
+- Hotfix: incorrect sorting in CAP weights file related to #144
+- Added some more to the RecSec docstring

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,28 +26,3 @@ make html
 
 See your locally built documentation by opening *_build/html/index.html*
 
-## Publishing Package on PyPi 
-*Useful link: https://realpython.com/pypi-publish-python-package/*
-
-1. Ensure your `pyproject.toml` file is set up properly; required fields are name and version
-2. Set dependencies, do **not(( pin exact versions but allow for upper and lower bounds; only list direct dependencies
-3. Include `tests/`, `docs/`, license, and MANIFEST files (MANIFIST used for including non-source code material
-4. Ensure you have an account on PyPi and TestPyPi (for testing publishing)
-5. Install `twine` and `build` which are used to build and push packages to PyPi
-6. Build your packages locally, which creates the `.tar.gz` and `.whl` dist files
-```bash
-python -m build
-```
-6. Check that files in your .whl (zip file) are as expected (including everything in 3)
-7. Check dist files with:
-```bash
-twine check dist/*
-```
-8. Upload test package (note: requires TestPyPi account)
-```bash
-twine upload -r testpypi dist/*
-```
-9. Upload real package (note: requires PyPi account)
-```bash
-twine upload dist/*
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysep-adjtomo"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python Seismogram Extraction and Processing"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -340,6 +340,12 @@ class RecordSection:
         :type trim: bool
         :param trim: trim waveforms to the same length, and if any data gaps
             are present, fill with mean values by default
+        :type taper: bool
+        :param taper: if True, taper ends of waveform during preprocessing. Uses
+            keyword arguments `max_percentage` (float) to define the percentage
+            to taper, and `taper_type` (str) to define shape of the taper. See
+            ObsPy's stream.taper() function for acceptable values for these
+            arguments.
         :type integrate: int
         :param integrate: apply integration `integrate` times on all traces.
             acceptable values [-inf, inf], where positive values are integration

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -98,7 +98,7 @@ def write_cap_weights_files(st, path_out="./", order_by="dist"):
 
     # Order codes based on distance, name or azimuth
     idx = ["code", "dist", "az"].index(order_by)
-    code_list = np.array(code_list)
+    code_list = np.array(code_list, dtype="object")
     ordered_codes = code_list[code_list[:, idx].argsort()]
 
     logger.info("writing CAP weight files")

--- a/pysep/utils/io.py
+++ b/pysep/utils/io.py
@@ -269,7 +269,7 @@ def read_specfem2d_source(path_to_source, origin_time=None):
     # First set dummy origin time
     if origin_time is None:
         origin_time = "1970-01-01T00:00:00"
-        logger.warning("no origin time set for SPECFEM2D source, setting "
+        logger.info("no origin time set for SPECFEM2D source, setting "
                        f"dummy value: {origin_time}")
 
     with open(path_to_source, "r") as f:


### PR DESCRIPTION
## Changelog
- Hotfix: incorrect sorting in CAP weights file related to #144

A few small riders 
- Change log level from warning -> info for empty origin time when reading SPECFEM sources
- Remove README doc page about publishing to PyPi, moved this to adjDocs
- Added some more to the RecSec docstring 