### PR TITLE
RecordSection allow export traces and ignore locations

### DIFF
--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -2531,7 +2531,6 @@ def parse_args():
     parsed, unknown = parser.parse_known_args()
     for arg in unknown:
         if arg.startswith(("-", "--")):
-            import pdb;pdb.set_trace()
             parser.add_argument(arg.split("=")[0])
 
     return parser

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -130,7 +130,7 @@ class RecordSection:
             # Data input parameters
             self, pysep_path=None, syn_path=None, stations=None, source=None, 
             st=None, st_syn=None, windows=None, synsyn=False, srcfmt=None, 
-            wildcard="*", syn_wildcard=None, 
+            wildcard="*", syn_wildcard=None, ignore_location=False,
             # Data organization parameters
             sort_by="default", scale_by=None, time_shift_s=None, 
             zero_pad_s=None, move_out=None, 
@@ -725,7 +725,15 @@ class RecordSection:
         if self.st_syn is not None:
             self.st, self.st_syn = subset_streams(self.st, self.st_syn)
 
-            if len(self.st) != len(self.st_syn):
+            if len(self.st) == 0:
+                err.st = f"stream subset removed all traces from `st`, "\
+                         f"please check that you have matching input data"
+            elif len(self.st_syn) == 0:
+                err.st_syn = (
+                    f"stream subset removed all traces from `st_syn`, "
+                    f"please check that you have matching input data"
+                    )
+            elif len(self.st) != len(self.st_syn):
                 err.st_syn = f"length must match `st` (which is {len(self.st)})"
 
         # Check the `sort_by` sorting parameter options

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -2479,7 +2479,7 @@ def parse_args():
                         help="Integrate (positive values) or differentiate "
                              "(negative values) `integrate` times. e.g., -2 "
                              "will differentiate all waveforms twice.")
-    parser.add_argument("--xlim_s", default=None, type=int, nargs="+",
+    parser.add_argument("--xlim_s", default=None, type=float, nargs="+",
                         help="Min and max x limits in units seconds. Input as "
                              "a list, e.g., --xlim_s 10 200 ...")
     parser.add_argument("--zero_pad_s", default=None, type=float, nargs="+",

--- a/pysep/tests/test_recsec.py
+++ b/pysep/tests/test_recsec.py
@@ -158,3 +158,22 @@ def test_recsec_zero_amplitude(recsec):
     recsec.process_st()
     recsec.get_parameters()
     recsec.plot()
+
+
+def test_recsec_mismatched_locations(recsec_w_synthetics):
+    """
+    Test when RecSec encounters stations that match all their station code 
+    except for location code, which is sometimes used as a free-floating 
+    parameter to indicate e.g., synthetics or something and doesn't always
+    determine that waveforms do not match.
+    """
+    # Ensure that the location codes for `st` and `st_syn` differ 
+    for tr in recsec_w_synthetics.st:
+        tr.stats.location = "11"
+    for tr in recsec_w_synthetics.st_syn:
+        tr.stats.location = "00"
+
+    recsec_w_synthetics.check_parameters()
+    
+    pytest.set_trace()
+    

--- a/pysep/tests/test_recsec.py
+++ b/pysep/tests/test_recsec.py
@@ -160,6 +160,21 @@ def test_recsec_zero_amplitude(recsec):
     recsec.plot()
 
 
+def test_recsec_mismatched_locations_fails(recsec_w_synthetics):
+    """
+    Test that when RecSec encounters stations with different location codes, 
+    it fails the parameter check
+    """
+    # Ensure that the location codes for `st` and `st_syn` differ 
+    for tr in recsec_w_synthetics.st:
+        tr.stats.location = "11"
+    for tr in recsec_w_synthetics.st_syn:
+        tr.stats.location = "00"
+
+    with pytest.raises(SystemExit):
+        recsec_w_synthetics.check_parameters()
+
+        
 def test_recsec_mismatched_locations(recsec_w_synthetics):
     """
     Test when RecSec encounters stations that match all their station code 
@@ -173,7 +188,9 @@ def test_recsec_mismatched_locations(recsec_w_synthetics):
     for tr in recsec_w_synthetics.st_syn:
         tr.stats.location = "00"
 
+    recsec_w_synthetics.remove_locations = True
     recsec_w_synthetics.check_parameters()
-    
-    pytest.set_trace()
+    recsec_w_synthetics.process_st()
+    recsec_w_synthetics.get_parameters()
+    recsec_w_synthetics.plot()
     


### PR DESCRIPTION
Small features that 1) allow exporting processed waveforms from RecordSection so that these waveforms can be used in other plotting tools or further analysis, and 2) ignoring location codes when matching data to synthetics when creating RecordSections


## Changelog
- New RecordSection command line argument `--export_traces` or class argument `export_traces` can be used interchangeably to trigger trace export 
- `export_traces` boolean flag triggers export of both `st` and `st_syn` (if available) as SAC files 
- Files are exported in the same directory they were read from, with appended suffixes (`_st_proc` and `_syn_proc` for data and synthetics, respectively), separated by component
- New command line argument `--remove_locations` or class argument `remove_locations` to not take location code into account when matching `obs` and `syn` data
- `--remove_locations` strips location codes from traces in `st` and `st_syn` so that they will match. User should take care here as the same station may have multiple location codes and that will fail in this case
- User should also be aware that because the location codes are actually removed (replaced with ''), the output figures and any traces that are exported with `--export_traces` will **not** match the input data naming
- Allow command line `--xlim_s` input as floating point (previously forced to int)