### PR TITLE
Bugfix SAC header NZMSEC overflow causing incorrect SAC header origin time

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1648,6 +1648,7 @@ class Pysep:
 
             fid = os.path.join(output_dir, tag)
             logger.debug(os.path.basename(fid))
+            import pdb;pdb.set_trace()
             tr.write(fid, format="SAC")
 
     def write_config(self, fid=None, overwrite=False):

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1648,7 +1648,6 @@ class Pysep:
 
             fid = os.path.join(output_dir, tag)
             logger.debug(os.path.basename(fid))
-            import pdb;pdb.set_trace()
             tr.write(fid, format="SAC")
 
     def write_config(self, fid=None, overwrite=False):

--- a/pysep/tests/test_declust.py
+++ b/pysep/tests/test_declust.py
@@ -1,5 +1,7 @@
 """
 Test the declustering algorithm
+
+For debugging, to show figures turn SHOW in __init__.py to True
 """
 import os
 import pytest

--- a/pysep/tests/test_recsec.py
+++ b/pysep/tests/test_recsec.py
@@ -14,8 +14,8 @@ from copy import copy
 from pysep import RecordSection
 
 
-# For debugging, turn to True when running tests to show the plots 
-SHOW = True
+# For debugging, to show figures turn SHOW=True
+SHOW=False
 
 @pytest.fixture
 def recsec(tmpdir):

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -8,7 +8,7 @@ import os
 import pytest
 import numpy as np
 from glob import glob
-from obspy import read, read_events, read_inventory, Stream
+from obspy import read, read_events, read_inventory, Stream, UTCDateTime
 from obspy.io.sac.sactrace import SACTrace
 from pysep.utils.cap_sac import (append_sac_headers,
                                  format_sac_header_w_taup_traveltimes,
@@ -101,11 +101,24 @@ def test_sac_header_correct_origin_time(tmpdir, test_st, test_inv, test_event):
     sac = SACTrace.read(os.path.join(tmpdir, "test.sac"))
 
     import pdb;pdb.set_trace()
-
     assert(sac.reftime == test_event.preferred_origin().time)
 
-    # We should have truncated this value to ensure that NZMSEC is only 3 digits
-    # Related to Issue #152
+
+def test_sac_header_correct_nzmsec(tmpdir, test_st, test_inv, test_event):
+    """
+    Make sure NZMSEC is written properly and doesnt change values
+
+    Related to Issue #152
+    """
+    test_event.preferred_origin().time = \
+            UTCDateTime("2009-04-07T20:12:55.999999Z")
+    st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
+    st[0].write(os.path.join(tmpdir, "test.sac"), format="SAC")  # only write 1
+    st_read = read(os.path.join(tmpdir, "test.sac"))
+    sac = SACTrace.read(os.path.join(tmpdir, "test.sac"))
+
+    import pdb;pdb.set_trace()
+
     assert(sac.nzmsec != test_event.preferred_origin().time.microsecond)
 
 

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -99,7 +99,14 @@ def test_sac_header_correct_origin_time(tmpdir, test_st, test_inv, test_event):
     st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
     st[0].write(os.path.join(tmpdir, "test.sac"), format="SAC")  # only write 1
     sac = SACTrace.read(os.path.join(tmpdir, "test.sac"))
+
+    import pdb;pdb.set_trace()
+
     assert(sac.reftime == test_event.preferred_origin().time)
+
+    # We should have truncated this value to ensure that NZMSEC is only 3 digits
+    # Related to Issue #152
+    assert(sac.nzmsec != test_event.preferred_origin().time.microsecond)
 
 
 def test_write_cap_weights_files(tmpdir, test_st, test_inv, test_event):
@@ -316,3 +323,4 @@ def test_get_gcmt_moment_tensor():
     assert(pytest.approx(m_rr, 1E-20) == 3.56E20)
 
     return event
+

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -100,26 +100,7 @@ def test_sac_header_correct_origin_time(tmpdir, test_st, test_inv, test_event):
     st[0].write(os.path.join(tmpdir, "test.sac"), format="SAC")  # only write 1
     sac = SACTrace.read(os.path.join(tmpdir, "test.sac"))
 
-    import pdb;pdb.set_trace()
     assert(sac.reftime == test_event.preferred_origin().time)
-
-
-def test_sac_header_correct_nzmsec(tmpdir, test_st, test_inv, test_event):
-    """
-    Make sure NZMSEC is written properly and doesnt change values
-
-    Related to Issue #152
-    """
-    test_event.preferred_origin().time = \
-            UTCDateTime("2009-04-07T20:12:55.999999Z")
-    st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
-    st[0].write(os.path.join(tmpdir, "test.sac"), format="SAC")  # only write 1
-    st_read = read(os.path.join(tmpdir, "test.sac"))
-    sac = SACTrace.read(os.path.join(tmpdir, "test.sac"))
-
-    import pdb;pdb.set_trace()
-
-    assert(sac.nzmsec != test_event.preferred_origin().time.microsecond)
 
 
 def test_write_cap_weights_files(tmpdir, test_st, test_inv, test_event):

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -198,7 +198,7 @@ def _append_sac_headers_trace(tr, event, inv):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": otime.microsecond,
+        "nzmsec": int(f"{otime.microsecond:0>6}"[3:]),  # micros->ms see #152
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees
@@ -336,7 +336,7 @@ def _append_sac_headers_cartesian_trace(tr, event, rcv_x, rcv_y):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": otime.microsecond,
+        "nzmsec": int(f"{otime.microsecond:0>6}"[3:]),  # micros->ms see #152
         "lpspol": 0,  # 1 if left-hand polarity (usually no in passive seis)
         "lcalda": 1,  # 1 if DIST, AZ, BAZ, GCARC to be calc'd from metadata
     }

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -198,7 +198,7 @@ def _append_sac_headers_trace(tr, event, inv):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": int(f"{otime.microsecond:0>6}"[3:]),  # micros->ms see #152
+        "nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees
@@ -336,7 +336,7 @@ def _append_sac_headers_cartesian_trace(tr, event, rcv_x, rcv_y):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": int(f"{otime.microsecond:0>6}"[3:]),  # micros->ms see #152
+        "nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
         "lpspol": 0,  # 1 if left-hand polarity (usually no in passive seis)
         "lcalda": 1,  # 1 if DIST, AZ, BAZ, GCARC to be calc'd from metadata
     }

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -198,8 +198,7 @@ def _append_sac_headers_trace(tr, event, inv):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": otime.microsecond,
-        #"nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
+        "nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -198,7 +198,8 @@ def _append_sac_headers_trace(tr, event, inv):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
+        "nzmsec": otime.microsecond,
+        #"nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees
@@ -233,7 +234,8 @@ def _append_sac_headers_trace(tr, event, inv):
     for key in ["cmpinc", "cmpaz", "evdp", "mag"]:
         if key not in sac_header:
             _warn_about.append(key)
-    logger.warning(f"no SAC header values found for: {_warn_about}")
+    if _warn_about:
+        logger.warning(f"no SAC header values found for: {_warn_about}")
     
     # Append SAC header and include back azimuth for rotation
     tr.stats.sac = sac_header

--- a/pysep/utils/fetch.py
+++ b/pysep/utils/fetch.py
@@ -50,8 +50,8 @@ def get_taup_arrivals(st=None, event=None, inv=None, phase_list=("ttall",),
         contain information about phase arrivals
     """
     if st is not None:
-        logger.debug(f"using SAC headers to fetch phase arrivals '{phase_list}'"
-                     f"from model '{model}'")
+        logger.debug(f"using SAC headers to fetch phase arrivals "
+                     f"'{phase_list}' from model '{model}'")
     else:
         assert(event is not None and inv is not None), (
             f"`get_taup_arrivals` requires `st` w/ SAC headers OR `event` and " 


### PR DESCRIPTION
Related to SAC header time incorrectly saving and causing incorrect NZ time values in SAC header. See #152 for more information. Fixes this by forcibly truncating the `microsecond` attribute of the events `UTCDateTime` object to force it into 3 digit millseconds. Although SAC header says these should be allowable as integers, we'll just be safe and truncate. I threw in one or two random formatting fixes I found rooting around.