### PR TITLE
rearrange sac header writer

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -3,7 +3,7 @@
 Python Seismogram Extraction and Processing (PySEP)
 
 Download, pre-process, and organize seismic waveforms, event and station
-metadata. Save waveforms as SAC files for use in moment tensor inversion and 
+metadata. Save waveforms as SAC files for use in moment tensor inversion and
 adjoint tomography codes.
 """
 import argparse
@@ -513,7 +513,7 @@ class Pysep:
         self.demean = bool(demean)
         self.detrend = bool(detrend)
         self.taper_percentage = taper_percentage
-        self.rotate = rotate 
+        self.rotate = rotate
         self.remove_response = bool(remove_response)
         self.output_unit = output_unit
         self.water_level = water_level
@@ -1065,7 +1065,7 @@ class Pysep:
                     bulk.append((net.code, sta.code, self.locations,
                                  self.channels, t1, t2))
 
-        # Catch edge case where len(bulk)==0 which will cause ObsPy to fail 
+        # Catch edge case where len(bulk)==0 which will cause ObsPy to fail
         assert bulk, (
             f"station curtailing has removed any stations to query data for. "
             f"please check your `distance` and `azimuth` curtailing criteria "
@@ -1255,7 +1255,7 @@ class Pysep:
             logger.info(f"applying amplitude scale factor: {self.scale_factor}")
             for tr in st_out:
                 tr.data = tr.data * self.scale_factor
-                tr.stats.sac["scale"] = self.scale_factor
+                #tr.stats.sac["scale"] = self.scale_factor
         if self.client == "LLNL":
             # This won't do anything if we don't have any 'LL' network codes
             st_out = scale_llnl_waveform_amplitudes(st_out)
@@ -1554,7 +1554,7 @@ class Pysep:
             logger.info("writing stations file")
             logger.debug(fid)
             write_pysep_station_file(
-                    self.inv, self.event, fid, 
+                    self.inv, self.event, fid,
                     order_station_list_by=order_station_list_by
                     )
 
@@ -1660,8 +1660,8 @@ class Pysep:
         :type fid: str
         :param fid: name of the file to write. defaults to config.yaml
         :type overwrite: bool
-        :param overwrite: if True and `fid` already exists, save a new config 
-            file with the same name, overwriting the old file. if False 
+        :param overwrite: if True and `fid` already exists, save a new config
+            file with the same name, overwriting the old file. if False
             (default), throws a warning if encountering existing `fid` and does
             not write config file
         """
@@ -1774,7 +1774,7 @@ class Pysep:
 
         if not save_log:
             return
-    
+
         # Make the output directory that the log file will be saved in
         if not os.path.exists(self._output_dir):
             os.makedirs(self._output_dir)
@@ -1859,13 +1859,20 @@ class Pysep:
         # user wants it, it should have been written out
         del self.st_raw
 
+        ## Waveform preprocessing and standardization
+        self.st = self.preprocess()
+
         self.st = append_sac_headers(self.st, self.event, self.inv)
         if self.taup_model is not None:
-            self.st = format_sac_header_w_taup_traveltimes(self.st, 
+            self.st = format_sac_header_w_taup_traveltimes(self.st,
                                                            self.taup_model,
                                                            self.phase_list)
-        # Waveform preprocessing and standardization
-        self.st = self.preprocess()
+
+        ## Waveform preprocessing and standardization
+        #self.st = self.preprocess()
+        if self.scale_factor:
+            for tr in self.st:
+                tr.stats.sac["scale"] = self.scale_factor
 
         # Rotation to various orientations. The output stream will have ALL
         # components, both rotated and non-rotated

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -198,7 +198,7 @@ def _append_sac_headers_trace(tr, event, inv):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": otime.microsecond,
+        "nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees
@@ -235,7 +235,8 @@ def _append_sac_headers_trace(tr, event, inv):
     for key in ["cmpinc", "cmpaz", "evdp", "mag"]:
         if key not in sac_header:
             _warn_about.append(key)
-    logger.warning(f"no SAC header values found for: {_warn_about}")
+    if _warn_about:
+        logger.warning(f"no SAC header values found for: {_warn_about}")
 
     # Append SAC header and include back azimuth for rotation
     tr.stats.sac = sac_header
@@ -338,7 +339,7 @@ def _append_sac_headers_cartesian_trace(tr, event, rcv_x, rcv_y):
         "nzhour": otime.hour,
         "nzmin": otime.minute,
         "nzsec": otime.second,
-        "nzmsec": otime.microsecond,
+        "nzmsec": int(f"{otime.microsecond:0>6}"[:3]),  # micros->ms see #152
         "lpspol": 0,  # 1 if left-hand polarity (usually no in passive seis)
         "lcalda": 1,  # 1 if DIST, AZ, BAZ, GCARC to be calc'd from metadata
     }


### PR DESCRIPTION
I think there is a problem with the SAC header construction.

here

[pysep/pysep/pysep.py](https://github.com/adjtomo/pysep/blob/92c4c62b7fc900a80f9e0ca2a345faf3e62298e8/pysep/pysep.py#L1862)

Line 1862 in [92c4c62](https://github.com/adjtomo/pysep/commit/92c4c62b7fc900a80f9e0ca2a345faf3e62298e8)

 self.st = append_sac_headers(self.st, self.event, self.inv) 

pysep constructs the SAC header (before the trim), which means that it calculates the B value from the stream start time
here

[pysep/pysep/pysep.py](https://github.com/adjtomo/pysep/blob/92c4c62b7fc900a80f9e0ca2a345faf3e62298e8/pysep/pysep.py#L1868)

Line 1868 in [92c4c62](https://github.com/adjtomo/pysep/commit/92c4c62b7fc900a80f9e0ca2a345faf3e62298e8)

 self.st = self.preprocess() 

pysep calls the preprocess routine and trims the waves, setting the new stream start time.
Then it writes the SAC files (with the new start time and the previously defined header).

When the SAC file is read back, OBSPY takes into account the start time (defined by the trim) and the B value, and adjusts nzsec, nzmsec.
which will be used later to create the origin time.

So the origin time is modified in the sac files

I modified pysep.py moving the preprocess (where the trim occurs) before the sac header.

the proprocess routine assumed that a sac header was already written but only to write the scale_factor value, so I move this writing out of the routine after the sac header construction
